### PR TITLE
Fix typo: s/enableContol/enableControl/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ MusicControl.resetNowPlaying()
 **Enable/disable controls on lockscreen**
 
 ```javascript
-MusicControl.enableContol('nextTrack', true)
-MusicControl.enableContol('previousTrack', false)
+MusicControl.enableControl('nextTrack', true)
+MusicControl.enableControl('previousTrack', false)
 ```
 
 **Register to events**

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -115,7 +115,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void enableContol(String controlName, Boolean enabled) {
+    public void enableControl(String controlName, Boolean enabled) {
         this.enabledControls.putBoolean(controlName, enabled);
         updateNotification();
     }

--- a/index.android.js
+++ b/index.android.js
@@ -23,8 +23,8 @@ var MusicControl = {
   resetNowPlaying: function(){
     NativeMusicControl.resetNowPlaying()
   },
-  enableContol: function(controlName, enable){
-    NativeMusicControl.enableContol(controlName, enable)
+  enableControl: function(controlName, enable){
+    NativeMusicControl.enableControl(controlName, enable)
   },
   handleCommand: function(commandName){
     if(handlers[commandName]){

--- a/index.ios.js
+++ b/index.ios.js
@@ -23,8 +23,8 @@ var MusicControl = {
   resetNowPlaying: function(){
     NativeMusicControl.resetNowPlaying()
   },
-  enableContol: function(controlName, bool){
-    NativeMusicControl.enableContol(controlName, bool)
+  enableControl: function(controlName, bool){
+    NativeMusicControl.enableControl(controlName, bool)
   },
   handleCommand: function(commandName){
     if(handlers[commandName]){

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -106,7 +106,7 @@ RCT_EXPORT_METHOD(resetNowPlaying)
 }
 
 
-RCT_EXPORT_METHOD(enableContol:(NSString *) controlName enabled:(BOOL) enabled)
+RCT_EXPORT_METHOD(enableControl:(NSString *) controlName enabled:(BOOL) enabled)
 {
     MPRemoteCommandCenter *remoteCenter = [MPRemoteCommandCenter sharedCommandCenter];
 


### PR DESCRIPTION
#### What's this PR do?

Fixes typo in the `control` word.