### PR TITLE
Allow the artwork to be loaded from an arbitrary path

### DIFF
--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -211,11 +211,9 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
                 image = [UIImage imageWithData:imageData];
             } else {
                 // artwork is local. so create it from a UIImage
-                NSString *basePath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-                NSString *fullPath = [NSString stringWithFormat:@"%@%@", basePath, url];
-                BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:fullPath];
+                BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:url];
                 if (fileExists) {
-                    image = [UIImage imageNamed:fullPath];
+                    image = [UIImage imageNamed:url];
                 }
             }
         }


### PR DESCRIPTION
It's possible that someone will want to use the library with an image located outside of the documents directory. It's better to require an absolute path to the image.