### PR TITLE
Move all interactions with MPNowPlayingInfoCenter to the main thread

### DIFF
--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -18,6 +18,11 @@
 
 RCT_EXPORT_MODULE()
 
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_main_queue();
+}
+
 RCT_EXPORT_METHOD(setNowPlaying:(NSDictionary *) details)
 {
 


### PR DESCRIPTION
I noticed that control center behaved weirdly, for example buttons sometimes disappear. This was probably caused by the fact that we were accessing `MPNowPlayingInfoCenter` from a background thread.

After this change no such issues occur anymore.