### PR TITLE
adds react native directory to header search paths. fixes #8

### DIFF
--- a/ios/MusicControl.xcodeproj/project.pbxproj
+++ b/ios/MusicControl.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+					"$(SRCROOT)/../../react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				"LIBRARY_SEARCH_PATHS[arch=*]" = "$(inherited)";
@@ -217,6 +218,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
#### What's this PR do?
fixes #8  by adding react-native directories to the xcodeproject's header search paths.
#### Which issue(s) is it related to?
#8 
