### PR TITLE
Android remote event

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlBroadcastReceiver.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlBroadcastReceiver.java
@@ -1,36 +1,21 @@
 package com.tanguyantoine.react;
 
 
-import android.app.Service;
 import android.content.Intent;
+import android.content.Context;
 import android.os.IBinder;
 import android.util.Log;
+import android.content.BroadcastReceiver;
+import android.support.v4.content.LocalBroadcastManager;
 
-public class MusicControlBroadcastReceiver extends Service {
-    public static final String ACTION_PLAY = "action_play";
-    public static final String ACTION_PAUSE = "action_pause";
-    public static final String ACTION_REWIND = "action_rewind";
-    public static final String ACTION_FAST_FORWARD = "action_fast_foward";
-    public static final String ACTION_NEXT = "action_next";
-    public static final String ACTION_PREVIOUS = "action_previous";
-    public static final String ACTION_STOP = "action_stop";
+public class MusicControlBroadcastReceiver extends BroadcastReceiver {
 
 
     @Override
-    public void onCreate() {
-        super.onCreate();
-        Log.i("Service", "Created service");
-    }
-    @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
-        Log.i("Service", "onStartCommand called " + intent.getAction());
-        sendBroadcast(intent);
-        return START_STICKY;
-    }
-
-    @Override
-    public IBinder onBind(Intent arg0) {
-        return null;
+    public void onReceive(Context context,Intent intent) {
+        Intent newIntent = new Intent();
+        newIntent.setAction(intent.getAction());
+        LocalBroadcastManager.getInstance(context).sendBroadcast(newIntent);
     }
 
 }

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -205,12 +205,12 @@ public class MusicControlModule extends ReactContextBaseJavaModule {
     private void updateNotification(){
         initNotificationBuilder();
         //artwork uri : path absolute
-        //String filePath = infos.getString("artwork");
-        //Bitmap mybitmap = getBitmapCover(filePath);
+        String filePath = infos.hasKey("artwork") ? infos.getString("artwork") : "";
+        Bitmap mybitmap = getBitmapCover(filePath);
 
         this.notificationBuilder.setSmallIcon(android.R.drawable.ic_media_play);
         //icono largo es bitmap
-        //this.notificationBuilder.setLargeIcon(mybitmap);
+        this.notificationBuilder.setLargeIcon(mybitmap);
         String title = infos.hasKey("title") ? infos.getString("title") : "";
         String content = infos.hasKey("artist") ? infos.getString("artist") : "";
         this.notificationBuilder

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -20,6 +20,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.IBinder;
 import android.util.Log;
+import android.support.v4.content.LocalBroadcastManager;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -75,12 +76,16 @@ public class MusicControlModule extends ReactContextBaseJavaModule {
         this.enabledControls = new WritableNativeMap();
         this.infos = new ReadableNativeMap();
 
-        IntentFilter intentFilter = new IntentFilter("nextTrack");
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(ACTION_PLAY);
+        intentFilter.addAction(ACTION_PAUSE);
+        intentFilter.addAction(ACTION_PREVIOUS);
+        intentFilter.addAction(ACTION_NEXT);
 
-        reactContext.registerReceiver(new BroadcastReceiver() {
+        LocalBroadcastManager.getInstance(reactContext).registerReceiver(new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
-                sendEvent("nextTrack");
+                sendEvent(intent.getAction());
             }
         }, intentFilter);
     }
@@ -135,17 +140,15 @@ public class MusicControlModule extends ReactContextBaseJavaModule {
 
 
     private void sendEvent(String eventName) {
-        WritableMap params = Arguments.createMap();
-        params.putString("name", eventName);
         reactContext
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit(MUSIC_CONTROL_EVENT_NAME, params);
+                .emit(MUSIC_CONTROL_EVENT_NAME, eventName);
     }
 
     private Notification.Action generateAction(int icon, String title, String intentAction) {
         Intent intent = new Intent(reactContext, MusicControlBroadcastReceiver.class);
         intent.setAction(intentAction);
-        PendingIntent pendingIntent = PendingIntent.getService(reactContext, 1, intent, 0);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(reactContext, 1, intent, 0);
         return new Notification.Action.Builder(icon, title, pendingIntent).build();
     }
 
@@ -202,12 +205,12 @@ public class MusicControlModule extends ReactContextBaseJavaModule {
     private void updateNotification(){
         initNotificationBuilder();
         //artwork uri : path absolute
-        String filePath = infos.getString("artwork");
-        Bitmap mybitmap = getBitmapCover(filePath);
+        //String filePath = infos.getString("artwork");
+        //Bitmap mybitmap = getBitmapCover(filePath);
 
         this.notificationBuilder.setSmallIcon(android.R.drawable.ic_media_play);
         //icono largo es bitmap
-        this.notificationBuilder.setLargeIcon(mybitmap);
+        //this.notificationBuilder.setLargeIcon(mybitmap);
         String title = infos.hasKey("title") ? infos.getString("title") : "";
         String content = infos.hasKey("artist") ? infos.getString("artist") : "";
         this.notificationBuilder


### PR DESCRIPTION
I managed to make the android remote events ('play', 'pause', 'nextTrack', 'previousTrack') work, by adding an extra line in app's AndroidManifest.xml

`<receiver android:name="com.tanguyantoine.react.MusicControlBroadcastReceiver"></receiver>`

and it will be handled in react-native like
```javascript

componentDidMount() {
  this.subscription = DeviceEventEmitter.addListener('RNMusicControlEvent',this._androidRemoteControlEvent.bind(this))
}

_androidRemoteControlEvent(event){
    switch (event) {
      case 'play':
        // play
        break
      case 'pause':
        // pause
        break
      case 'nextTrack':
        // next
        break
      case 'previousTrack':
        // prev
        break
      default:
        break
    }
  }

```

The implementation may not the best (not an Android expert) but it works for me, see if you want to merge :)