### PR TITLE
Loads only the artwork in a another thread and fixes MediaSession thr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ dependencies {
 ```diff
 ...
 include ':app'
-+ include ':react-native-music-control'
-+ project(':react-native-music-control').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-music-control/android')
++include ':react-native-music-control'
++project(':react-native-music-control').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-music-control/android')
 ```
 
 **MainActivity.java**
@@ -123,6 +123,7 @@ MusicControl.resetNowPlaying()
 **Enable/disable controls**
 
 iOS: Lockscreen
+
 Android: Notification and external devices (cars, watches)
 
 ```javascript
@@ -187,7 +188,7 @@ componentDidMount() {
     MusicControl.on('disableLanguageOption', ()=> {}); // iOS only
     MusicControl.on('skipForward', ()=> {}); // iOS only
     MusicControl.on('skipBackward', ()=> {}); // iOS only
-  }
+}
 ```
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,11 +11,11 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 16 // RN's minimum version
-        targetSdkVersion 23
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
         ndk {
@@ -30,6 +30,5 @@ repositories {
 }
 
 dependencies {
-    compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,8 @@
-<manifest xml:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.tanguyantoine.MusicControl">
+
+    <application>
+        <service android:stopWithTask="false" android:name="com.tanguyantoine.react.MusicControlNotification$NotificationService" />
+    </application>
+
 </manifest>

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -2,7 +2,6 @@ package com.tanguyantoine.react;
 
 import android.app.PendingIntent;
 import android.app.Service;
-import android.content.ComponentName;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.os.IBinder;
@@ -17,13 +16,16 @@ public class MusicControlNotification {
     protected static final String REMOVE_NOTIFICATION = "remove_notification";
 
     private final ReactApplicationContext context;
-    private final ComponentName compName;
 
+    private int smallIcon;
     private NotificationCompat.Action play, pause, stop, next, previous;
 
-    public MusicControlNotification(ReactApplicationContext context, ComponentName compName) {
+    public MusicControlNotification(ReactApplicationContext context) {
         this.context = context;
-        this.compName = compName;
+
+        Resources r = context.getResources();
+        String packageName = context.getPackageName();
+        smallIcon = r.getIdentifier("play", "drawable", packageName);
     }
 
     public void updateActions(long mask) {
@@ -45,6 +47,7 @@ public class MusicControlNotification {
         if(next != null) builder.addAction(next);
 
         builder.setOngoing(isPlaying);
+        builder.setSmallIcon(smallIcon);
 
         // Open the app when the notification is clicked
         Intent openApp = new Intent(context, context.getClass());
@@ -101,7 +104,6 @@ public class MusicControlNotification {
         // Replace this to MediaButtonReceiver.buildMediaButtonPendingIntent when React Native updates the support library
         int keyCode = toKeyCode(action);
         Intent intent = new Intent(Intent.ACTION_MEDIA_BUTTON);
-        intent.setComponent(compName);
         intent.putExtra(Intent.EXTRA_KEY_EVENT, new KeyEvent(KeyEvent.ACTION_DOWN, keyCode));
         PendingIntent i = PendingIntent.getBroadcast(context, keyCode, intent, 0);
 
@@ -121,7 +123,9 @@ public class MusicControlNotification {
 
         @Override
         public void onTaskRemoved(Intent rootIntent) {
-            MusicControlModule.INSTANCE.destroy();
+            if(MusicControlModule.INSTANCE != null) {
+                MusicControlModule.INSTANCE.destroy();
+            }
             stopSelf();
         }
 

--- a/index.android.js
+++ b/index.android.js
@@ -1,6 +1,4 @@
 /**
- * Stub of MusicControl for Android.
- *
  * @providesModule MusicControl
  * @flow
  */
@@ -28,7 +26,7 @@ var MusicControl = {
   },
   setPlayback: function(info){
     NativeMusicControl.setPlayback(info)
-  }
+  },
   resetNowPlaying: function(){
     NativeMusicControl.resetNowPlaying()
   },


### PR DESCRIPTION
After I was done with the recode, I started playing with it and I found a few bugs:
* Notification/MediaSession were not removed after the app terminated
* Removed the support library from the dependencies as it is already included in React Native.
* Now only the artwork will be loaded in another thread. The metadata will not be blocked anymore
* Added an icon for the notification, so Android will not complain about it.