### PR TITLE
Toggle pause method for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ MusicControl.enableControl('enableLanguageOption', false); // iOS only
 MusicControl.enableControl('disableLanguageOption', false); // iOS only
 MusicControl.enableControl('skipForward', false); // iOS only
 MusicControl.enableControl('skipBackward', false); // iOS only
+
+MusicControl.togglePause(45); // Elapsed time in seconds, iOS only
 ```
 
 `skipBackward` and `skipForward` controls on iOS accept additional configuration options with `interval` key:

--- a/index.ios.js
+++ b/index.ios.js
@@ -14,6 +14,9 @@ var handlers = { };
 var subscription = null;
 
 var MusicControl = {
+  togglePause: function(elapsed) {
+    NativeMusicControl.togglePause(elapsed);
+  },
   enableBackgroundMode: function(enable){
     NativeMusicControl.enableBackgroundMode(enable)
   },

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -23,6 +23,27 @@ RCT_EXPORT_MODULE()
     return dispatch_get_main_queue();
 }
 
+RCT_EXPORT_METHOD(togglePause:(nonnull NSNumber *) elapsed)
+{
+    MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
+    
+    if (center.nowPlayingInfo == nil) {
+        return;
+    }
+    
+    NSMutableDictionary *mediaDict = [[NSMutableDictionary alloc] initWithDictionary: center.nowPlayingInfo];
+
+    NSNumber *speed = [[mediaDict objectForKey:MPNowPlayingInfoPropertyPlaybackRate] isEqual:[NSNumber numberWithDouble:0]]
+        ? [NSNumber numberWithDouble:1]
+        : [NSNumber numberWithDouble:0];
+
+    
+    [mediaDict setValue:speed forKey:MPNowPlayingInfoPropertyPlaybackRate];
+    [mediaDict setValue:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
+    
+    center.nowPlayingInfo = mediaDict;
+}
+
 RCT_EXPORT_METHOD(setNowPlaying:(NSDictionary *) details)
 {
 


### PR DESCRIPTION
#### What's this PR do?
Adds a new method to iOS so that the duration bar can be paused when pause is pressed. Currently when pause is hit, the duration bar keeps going forward. 

#### Which issue(s) is it related to?
[#40](https://github.com/tanguyantoine/react-native-music-control/issues/40)

#### How to test:
Toggle pause after the playback has started. It will stop the duration bar and set the stopped time to the elapsed time. All other details of the info will remain what it was before.
