### PR TITLE
Support for "require('./image.png)" keyword for artwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ NB: You should call this method after a sound is playing
 ```javascript
 MusicControl.setNowPlaying({
   title: 'Billie Jean',
-  artwork: 'http://lorempixel.com/400/400', // URL or File path
+  artwork: 'http://lorempixel.com/400/400', // URL, File path or require() ('require' support is Android only)
   artist: 'Michael Jackson',
   album: 'Thriller',
   genre: 'Post-disco, Rhythm and Blues, Funk, Dance-pop',

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -299,19 +299,19 @@ public class MusicControlModule extends ReactContextBaseJavaModule {
         Bitmap bitmap = null;
 
         try {
-            if(artworkReactAsset) {
+            if(url.matches("^(https?|ftp)://.*$")) { // URL
+                URLConnection con = new URL(url).openConnection();
+                con.connect();
+                InputStream input = con.getInputStream();
+                bitmap = BitmapFactory.decodeStream(input);
+                input.close();
+            } else if(artworkReactAsset) {
                 //Artwork passed using require('./image.png);
                 Drawable image = ResourceDrawableIdHelper
                         .getInstance()
                         .getResourceDrawable(this.getReactApplicationContext(), url);
 
                 bitmap = ((BitmapDrawable) image).getBitmap();
-            } else if(url.matches("^(https?|ftp)://.*$")) { // URL
-                URLConnection con = new URL(url).openConnection();
-                con.connect();
-                InputStream input = con.getInputStream();
-                bitmap = BitmapFactory.decodeStream(input);
-                input.close();
             } else { // File
                 bitmap = BitmapFactory.decodeFile(url);
             }

--- a/index.android.js
+++ b/index.android.js
@@ -25,11 +25,10 @@ var MusicControl = {
   setNowPlaying: function(info){
     //Check if we have an android asset id from react style image "require('./image.png')"
     if (info.artwork && !isNaN(info.artwork)) {
-      info.artwork = resolveAssetSource(info.artwork).uri;
-      info.fromRequire = true;
+      info.artwork = resolveAssetSource(info.artwork);
     }
 
-    NativeMusicControl.setNowPlaying(info)
+    NativeMusicControl.setNowPlaying(info);
   },
   setPlayback: function(info){
     NativeMusicControl.setPlayback(info)

--- a/index.android.js
+++ b/index.android.js
@@ -6,6 +6,7 @@
 
 import { NativeModules, DeviceEventEmitter } from 'react-native';
 const NativeMusicControl = NativeModules.MusicControlManager;
+import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 
 var handlers = { };
 var subscription = null;
@@ -22,6 +23,12 @@ var MusicControl = {
     NativeMusicControl.enableBackgroundMode(enable)
   },
   setNowPlaying: function(info){
+    //Check if we have an android asset id from react style image "require('./image.png')"
+    if (info.artwork && !isNaN(info.artwork)) {
+      info.artwork = resolveAssetSource(info.artwork).uri;
+      info.fromRequire = true;
+    }
+
     NativeMusicControl.setNowPlaying(info)
   },
   setPlayback: function(info){


### PR DESCRIPTION
#### What's this PR do?
It will allow users to use the require keyword to load images for album artwork. e.g 
`MusicControl.setNowPlaying({ artwork: require('../img/album.png') });`
Android only.

#### Which issue(s) is it related to?
https://github.com/tanguyantoine/react-native-music-control/issues/43

#### How to test:
Use the require keyword to load an image and check if it shows as the album artwork
