### PR TITLE
Added updatePlayback and setPlayback. Some refactoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ MusicControl.enableControl('enableLanguageOption', false); // iOS only
 MusicControl.enableControl('disableLanguageOption', false); // iOS only
 MusicControl.enableControl('skipForward', false); // iOS only
 MusicControl.enableControl('skipBackward', false); // iOS only
+
+MusicControl.togglePause(45); // Elapsed time in seconds, iOS only
 ```
 
 `skipBackward` and `skipForward` controls on iOS accept additional configuration options with `interval` key:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ MusicControl.setNowPlaying({
 
 **Playback**
 
-Currently, Android only
+Android
 
 ```javascript
 MusicControl.setPlayback({
@@ -123,6 +123,17 @@ MusicControl.setPlayback({
   bufferedTime: 200 // (Seconds)
 })
 ```
+
+iOS
+```javascript
+// Any key that exists can be updated using this method
+MusicControl.updatePlayback({
+  speed: 1, // Playback Rate
+  elapsedTime: 103 // (Seconds)
+})
+```
+
+`setPlayback` will also work.
 
 **Reset now playing**
 
@@ -152,8 +163,6 @@ MusicControl.enableControl('enableLanguageOption', false); // iOS only
 MusicControl.enableControl('disableLanguageOption', false); // iOS only
 MusicControl.enableControl('skipForward', false); // iOS only
 MusicControl.enableControl('skipBackward', false); // iOS only
-
-MusicControl.togglePause(45); // Elapsed time in seconds, iOS only
 ```
 
 `skipBackward` and `skipForward` controls on iOS accept additional configuration options with `interval` key:

--- a/README.md
+++ b/README.md
@@ -135,6 +135,21 @@ MusicControl.updatePlayback({
 
 `setPlayback` will also work.
 
+**Pause/Resume playing**
+```javascript
+# Pause
+MusicControl.updatePlayback({
+  state: MuiscControl.STATE_PAUSED, // Playback Rate
+  elapsedTime: 103 // (Seconds) Current time from your player
+});
+
+# Resume
+MusicControl.updatePlayback({
+  state: MuiscControl.STATE_PLAYING, // Playback Rate
+  elapsedTime: 103 // (Seconds) Current time from your player
+});
+```
+
 **Reset now playing**
 
 ```javascript

--- a/index.ios.js
+++ b/index.ios.js
@@ -14,6 +14,9 @@ var handlers = { };
 var subscription = null;
 
 var MusicControl = {
+  togglePause: function(elapsed) {
+    NativeMusicControl.togglePause(elapsed);
+  },
   enableBackgroundMode: function(enable){
     NativeMusicControl.enableBackgroundMode(enable)
   },

--- a/index.ios.js
+++ b/index.ios.js
@@ -14,6 +14,8 @@ var handlers = { };
 var subscription = null;
 
 var MusicControl = {
+  STATE_PLAYING: NativeMusicControl.STATE_PLAYING,
+  STATE_PAUSED: NativeMusicControl.STATE_PAUSED,
   setPlayback: function (info) {
     NativeMusicControl.updatePlayback(info);
   },

--- a/index.ios.js
+++ b/index.ios.js
@@ -14,8 +14,8 @@ var handlers = { };
 var subscription = null;
 
 var MusicControl = {
-  togglePause: function(elapsed) {
-    NativeMusicControl.togglePause(elapsed);
+  updatePlaying: function(info) {
+    NativeMusicControl.updatePlaying(info);
   },
   enableBackgroundMode: function(enable){
     NativeMusicControl.enableBackgroundMode(enable)

--- a/index.ios.js
+++ b/index.ios.js
@@ -16,6 +16,9 @@ var subscription = null;
 var MusicControl = {
   STATE_PLAYING: NativeMusicControl.STATE_PLAYING,
   STATE_PAUSED: NativeMusicControl.STATE_PAUSED,
+  STATE_ERROR: NativeMusicControl.STATE_PAUSED,
+  STATE_STOPPED: NativeMusicControl.STATE_PAUSED,
+  STATE_BUFFERING: NativeMusicControl.STATE_PAUSED
   setPlayback: function (info) {
     NativeMusicControl.updatePlayback(info);
   },

--- a/index.ios.js
+++ b/index.ios.js
@@ -14,8 +14,11 @@ var handlers = { };
 var subscription = null;
 
 var MusicControl = {
-  updatePlaying: function(info) {
-    NativeMusicControl.updatePlaying(info);
+  setPlayback: function (info) {
+    NativeMusicControl.updatePlayback(info);
+  },
+  updatePlayback: function(info) {
+    NativeMusicControl.updatePlayback(info);
   },
   enableBackgroundMode: function(enable){
     NativeMusicControl.enableBackgroundMode(enable)

--- a/index.ios.js
+++ b/index.ios.js
@@ -18,7 +18,7 @@ var MusicControl = {
   STATE_PAUSED: NativeMusicControl.STATE_PAUSED,
   STATE_ERROR: NativeMusicControl.STATE_PAUSED,
   STATE_STOPPED: NativeMusicControl.STATE_PAUSED,
-  STATE_BUFFERING: NativeMusicControl.STATE_PAUSED
+  STATE_BUFFERING: NativeMusicControl.STATE_PAUSED,
   setPlayback: function (info) {
     NativeMusicControl.updatePlayback(info);
   },

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -23,6 +23,27 @@ RCT_EXPORT_MODULE()
     return dispatch_get_main_queue();
 }
 
+RCT_EXPORT_METHOD(togglePause:(nonnull NSNumber *) elapsed)
+{
+    MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
+    
+    if (center.nowPlayingInfo == nil) {
+        return;
+    }
+    
+    NSMutableDictionary *mediaDict = [[NSMutableDictionary alloc] initWithDictionary: center.nowPlayingInfo];
+
+    NSNumber *speed = [[mediaDict objectForKey:MPNowPlayingInfoPropertyPlaybackRate] isEqual:[NSNumber numberWithDouble:0]]
+        ? [NSNumber numberWithDouble:1]
+        : [NSNumber numberWithDouble:0];
+
+    
+    [mediaDict setValue:speed forKey:MPNowPlayingInfoPropertyPlaybackRate];
+    [mediaDict setValue:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
+    
+    center.nowPlayingInfo = mediaDict;
+}
+
 RCT_EXPORT_METHOD(setNowPlaying:(NSDictionary *) details)
 {
 

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -9,8 +9,11 @@
 @interface MusicControlManager ()
 
 @property (nonatomic, copy) NSString *artworkUrl;
+@property (nonatomic, strong) NSDictionary *mediaKeys;
 
 @end
+
+NSString * const MEDIA_PLAYBACK_RATE = @"playbackRate";
 
 @implementation MusicControlManager
 
@@ -18,12 +21,44 @@
 
 RCT_EXPORT_MODULE()
 
+- (NSDictionary *) mediaKeys {
+    if (_mediaKeys == nil) {
+        _mediaKeys = @{
+                @"album": MPMediaItemPropertyAlbumTitle,
+                @"trackCount": MPMediaItemPropertyAlbumTrackCount,
+                @"trackNumber": MPMediaItemPropertyAlbumTrackNumber,
+                @"artist": MPMediaItemPropertyArtist,
+                @"composer": MPMediaItemPropertyComposer,
+                @"discCount": MPMediaItemPropertyDiscCount,
+                @"discNumber": MPMediaItemPropertyDiscNumber,
+                @"genre": MPMediaItemPropertyGenre,
+                @"persistentID": MPMediaItemPropertyPersistentID,
+                @"duration": MPMediaItemPropertyPlaybackDuration,
+                @"title": MPMediaItemPropertyTitle,
+                @"elapsedPlaybackTime": MPNowPlayingInfoPropertyElapsedPlaybackTime,
+                @"playbackRate": MPNowPlayingInfoPropertyPlaybackRate,
+                @"playbackQueueIndex": MPNowPlayingInfoPropertyPlaybackQueueIndex,
+                @"playbackQueueCount": MPNowPlayingInfoPropertyPlaybackQueueCount,
+                @"chapterNumber": MPNowPlayingInfoPropertyChapterNumber,
+                @"chapterCount": MPNowPlayingInfoPropertyChapterCount
+           };
+    }
+    
+    return _mediaKeys;
+}
+
 - (dispatch_queue_t)methodQueue
 {
     return dispatch_get_main_queue();
 }
 
-RCT_EXPORT_METHOD(togglePause:(nonnull NSNumber *) elapsed)
+RCT_EXPORT_METHOD(setPlaying:(NSDictionary *) details)
+{
+    // For backwards compatibility
+    [self updatePlaying:details];
+}
+
+RCT_EXPORT_METHOD(updatePlaying:(NSDictionary *) details)
 {
     MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
     
@@ -32,99 +67,27 @@ RCT_EXPORT_METHOD(togglePause:(nonnull NSNumber *) elapsed)
     }
     
     NSMutableDictionary *mediaDict = [[NSMutableDictionary alloc] initWithDictionary: center.nowPlayingInfo];
-
-    NSNumber *speed = [[mediaDict objectForKey:MPNowPlayingInfoPropertyPlaybackRate] isEqual:[NSNumber numberWithDouble:0]]
-        ? [NSNumber numberWithDouble:1]
-        : [NSNumber numberWithDouble:0];
-
     
-    [mediaDict setValue:speed forKey:MPNowPlayingInfoPropertyPlaybackRate];
-    [mediaDict setValue:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
+    center.nowPlayingInfo = [self update:mediaDict with:details andSetDefaults:false];
     
-    center.nowPlayingInfo = mediaDict;
+    // Update the image if it exists
+    if ([details objectForKey:@"artwork"] != nil) {
+        self.artworkUrl = details[@"artwork"];
+    }
+    
+    [self updateNowPlayingArtwork];
 }
+
 
 RCT_EXPORT_METHOD(setNowPlaying:(NSDictionary *) details)
 {
-
+    
     MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
-
-    // Create media dictionary from existing keys or create a new one, this way we can update single attributes if we want to
-    NSMutableDictionary *mediaDict = (center.nowPlayingInfo != nil) ? [[NSMutableDictionary alloc] initWithDictionary: center.nowPlayingInfo] : [NSMutableDictionary dictionary];
-
-    if ([details objectForKey: @"album"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"album"] forKey:MPMediaItemPropertyAlbumTitle];
-    }
-
-    if ([details objectForKey: @"trackCount"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"trackCount"] forKey:MPMediaItemPropertyAlbumTrackCount];
-    }
-
-    if ([details objectForKey: @"trackNumber"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"trackNumber"] forKey:MPMediaItemPropertyAlbumTrackNumber];
-    }
-
-    if ([details objectForKey: @"artist"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"artist"] forKey:MPMediaItemPropertyArtist];
-    }
-
-    if ([details objectForKey: @"composer"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"composer"] forKey:MPMediaItemPropertyComposer];
-    }
-
-    if ([details objectForKey: @"discCount"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"discCount"] forKey:MPMediaItemPropertyDiscCount];
-    }
-
-    if ([details objectForKey: @"discNumber"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"discNumber"] forKey:MPMediaItemPropertyDiscNumber];
-    }
-
-    if ([details objectForKey: @"genre"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"genre"] forKey:MPMediaItemPropertyGenre];
-    }
-
-    if ([details objectForKey: @"persistentID"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"persistentID"] forKey:MPMediaItemPropertyPersistentID];
-    }
-
-    if ([details objectForKey: @"duration"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"duration"] forKey:MPMediaItemPropertyPlaybackDuration];
-    }
-
-    if ([details objectForKey: @"title"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"title"] forKey:MPMediaItemPropertyTitle];
-    }
-
-    if ([details objectForKey: @"elapsedPlaybackTime"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"elapsedPlaybackTime"] forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
-    }
-
-    if ([details objectForKey: @"playbackRate"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"playbackRate"] forKey:MPNowPlayingInfoPropertyPlaybackRate];
-    } else {
-        // In iOS Simulator, always include the MPNowPlayingInfoPropertyPlaybackRate key in your nowPlayingInfo dictionary
-        [mediaDict setValue:[NSNumber numberWithDouble:1] forKey:MPNowPlayingInfoPropertyPlaybackRate];
-    }
-
-    if ([details objectForKey: @"playbackQueueIndex"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"playbackQueueIndex"] forKey:MPNowPlayingInfoPropertyPlaybackQueueIndex];
-    }
-
-    if ([details objectForKey: @"playbackQueueCount"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"playbackQueueCount"] forKey:MPNowPlayingInfoPropertyPlaybackQueueCount];
-    }
-
-    if ([details objectForKey: @"chapterNumber"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"chapterNumber"] forKey:MPNowPlayingInfoPropertyChapterNumber];
-    }
-
-    if ([details objectForKey: @"chapterCount"] != nil) {
-        [mediaDict setValue:[details objectForKey: @"chapterCount"] forKey:MPNowPlayingInfoPropertyChapterCount];
-    }
-
-    center.nowPlayingInfo = mediaDict;
-
+    NSMutableDictionary *mediaDict = [NSMutableDictionary dictionary];
+    
+    
+    center.nowPlayingInfo = [self update:mediaDict with:details andSetDefaults:true];
+    
     // Custom handling of artwork in another thread, will be loaded async
     self.artworkUrl = details[@"artwork"];
     [self updateNowPlayingArtwork];
@@ -141,33 +104,33 @@ RCT_EXPORT_METHOD(resetNowPlaying)
 RCT_EXPORT_METHOD(enableControl:(NSString *) controlName enabled:(BOOL) enabled options:(NSDictionary *)options)
 {
     MPRemoteCommandCenter *remoteCenter = [MPRemoteCommandCenter sharedCommandCenter];
-
+    
     if ([controlName isEqual: @"pause"]) {
         [self toggleHandler:remoteCenter.pauseCommand withSelector:@selector(onPause:) enabled:enabled];
     } else if ([controlName isEqual: @"play"]) {
         [self toggleHandler:remoteCenter.playCommand withSelector:@selector(onPlay:) enabled:enabled];
-
+        
     } else if ([controlName isEqual: @"stop"]) {
         [self toggleHandler:remoteCenter.stopCommand withSelector:@selector(onStop:) enabled:enabled];
-
+        
     } else if ([controlName isEqual: @"togglePlayPause"]) {
         [self toggleHandler:remoteCenter.togglePlayPauseCommand withSelector:@selector(onTogglePlayPause:) enabled:enabled];
-
+        
     } else if ([controlName isEqual: @"enableLanguageOption"]) {
         [self toggleHandler:remoteCenter.enableLanguageOptionCommand withSelector:@selector(onEnableLanguageOption:) enabled:enabled];
-
+        
     } else if ([controlName isEqual: @"disableLanguageOption"]) {
         [self toggleHandler:remoteCenter.disableLanguageOptionCommand withSelector:@selector(onDisableLanguageOption:) enabled:enabled];
-
+        
     } else if ([controlName isEqual: @"nextTrack"]) {
         [self toggleHandler:remoteCenter.nextTrackCommand withSelector:@selector(onNextTrack:) enabled:enabled];
-
+        
     } else if ([controlName isEqual: @"previousTrack"]) {
         [self toggleHandler:remoteCenter.previousTrackCommand withSelector:@selector(onPreviousTrack:) enabled:enabled];
-
+        
     } else if ([controlName isEqual: @"seekForward"]) {
         [self toggleHandler:remoteCenter.seekForwardCommand withSelector:@selector(onSeekForward:) enabled:enabled];
-
+        
     } else if ([controlName isEqual: @"seekBackward"]) {
         [self toggleHandler:remoteCenter.seekBackwardCommand withSelector:@selector(onSeekBackward:) enabled:enabled];
     } else if ([controlName isEqual:@"skipBackward"]) {
@@ -193,10 +156,27 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
 
 #pragma mark internal
 
+- (NSDictionary *) update:(NSMutableDictionary *) mediaDict with:(NSDictionary *) details andSetDefaults:(BOOL) setDefault {
+    
+    for (NSString *key in [self mediaKeys]) {
+        if ([details objectForKey:key] != nil) {
+            [mediaDict setValue:[details objectForKey:key] forKey:[[self mediaKeys] objectForKey:key]];
+        }
+        
+        // In iOS Simulator, always include the MPNowPlayingInfoPropertyPlaybackRate key in your nowPlayingInfo dictionary
+        // only if we are creating a new dictionalty
+        if ([key isEqualToString:MEDIA_PLAYBACK_RATE] && [details objectForKey:key] == nil && setDefault) {
+            [mediaDict setValue:[NSNumber numberWithDouble:1] forKey:[[self mediaKeys] objectForKey:key]];
+        }
+    }
+        
+    return mediaDict;
+}
+
 - (void) toggleHandler:(MPRemoteCommand *) command withSelector:(SEL) selector enabled:(BOOL) enabled {
     [command removeTarget:self action:selector];
     if(enabled){
-        [command addTarget:self action:selector];        
+        [command addTarget:self action:selector];
     }
     command.enabled = enabled;
 }
@@ -233,7 +213,7 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
 
 - (void)sendEvent:(NSString*)event {
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"RNMusicControlEvent"
-                                                 body:@{@"name": event}];
+                                                    body:@{@"name": event}];
 }
 
 - (void)updateNowPlayingArtwork
@@ -256,19 +236,19 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
                 }
             }
         }
-
+        
         // Check if image was available otherwise don't do anything
         if (image == nil) {
             return;
         }
-
+        
         // check whether image is loaded
         CGImageRef cgref = [image CGImage];
         CIImage *cim = [image CIImage];
-
+        
         if (cim != nil || cgref != NULL) {
             dispatch_async(dispatch_get_main_queue(), ^{
-
+                
                 // Check if URL wasn't changed in the meantime
                 if ([url isEqual:self.artworkUrl]) {
                     MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -12,43 +12,31 @@
 
 @end
 
-NSString * const MEDIA_PLAYBACK_RATE = @"playbackRate";
+#define MEDIA_PLAYBACK_RATE @"speed"
+#define MEDIA_DICT @{@"album": MPMediaItemPropertyAlbumTitle, \
+    @"trackCount": MPMediaItemPropertyAlbumTrackCount, \
+    @"trackNumber": MPMediaItemPropertyAlbumTrackNumber, \
+    @"artist": MPMediaItemPropertyArtist, \
+    @"composer": MPMediaItemPropertyComposer, \
+    @"discCount": MPMediaItemPropertyDiscCount, \
+    @"discNumber": MPMediaItemPropertyDiscNumber, \
+    @"genre": MPMediaItemPropertyGenre, \
+    @"persistentID": MPMediaItemPropertyPersistentID, \
+    @"duration": MPMediaItemPropertyPlaybackDuration, \
+    @"title": MPMediaItemPropertyTitle, \
+    @"elapsedTime": MPNowPlayingInfoPropertyElapsedPlaybackTime, \
+    @"speed": MPNowPlayingInfoPropertyPlaybackRate, \
+    @"playbackQueueIndex": MPNowPlayingInfoPropertyPlaybackQueueIndex, \
+    @"playbackQueueCount": MPNowPlayingInfoPropertyPlaybackQueueCount, \
+    @"chapterNumber": MPNowPlayingInfoPropertyChapterNumber, \
+    @"chapterCount": MPNowPlayingInfoPropertyChapterCount \
+}
 
 @implementation MusicControlManager
 
 @synthesize bridge = _bridge;
 
 RCT_EXPORT_MODULE()
-
-- (NSDictionary *) mediaKeys {
-    static NSDictionary *dict = nil;
-    
-    static dispatch_once_t lock;
-    
-    dispatch_once(&lock, ^{
-        dict = @{
-             @"album": MPMediaItemPropertyAlbumTitle,
-             @"trackCount": MPMediaItemPropertyAlbumTrackCount,
-             @"trackNumber": MPMediaItemPropertyAlbumTrackNumber,
-             @"artist": MPMediaItemPropertyArtist,
-             @"composer": MPMediaItemPropertyComposer,
-             @"discCount": MPMediaItemPropertyDiscCount,
-             @"discNumber": MPMediaItemPropertyDiscNumber,
-             @"genre": MPMediaItemPropertyGenre,
-             @"persistentID": MPMediaItemPropertyPersistentID,
-             @"duration": MPMediaItemPropertyPlaybackDuration,
-             @"title": MPMediaItemPropertyTitle,
-             @"elapsedPlaybackTime": MPNowPlayingInfoPropertyElapsedPlaybackTime,
-             @"playbackRate": MPNowPlayingInfoPropertyPlaybackRate,
-             @"playbackQueueIndex": MPNowPlayingInfoPropertyPlaybackQueueIndex,
-             @"playbackQueueCount": MPNowPlayingInfoPropertyPlaybackQueueCount,
-             @"chapterNumber": MPNowPlayingInfoPropertyChapterNumber,
-             @"chapterCount": MPNowPlayingInfoPropertyChapterCount
-        };
-    });
-    
-    return dict;
-}
 
 - (dispatch_queue_t)methodQueue
 {
@@ -155,15 +143,15 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
 
 - (NSDictionary *) update:(NSMutableDictionary *) mediaDict with:(NSDictionary *) details andSetDefaults:(BOOL) setDefault {
     
-    for (NSString *key in [self mediaKeys]) {
+    for (NSString *key in MEDIA_DICT) {
         if ([details objectForKey:key] != nil) {
-            [mediaDict setValue:[details objectForKey:key] forKey:[[self mediaKeys] objectForKey:key]];
+            [mediaDict setValue:[details objectForKey:key] forKey:[MEDIA_DICT objectForKey:key]];
         }
         
         // In iOS Simulator, always include the MPNowPlayingInfoPropertyPlaybackRate key in your nowPlayingInfo dictionary
         // only if we are creating a new dictionary
         if ([key isEqualToString:MEDIA_PLAYBACK_RATE] && [details objectForKey:key] == nil && setDefault) {
-            [mediaDict setValue:[NSNumber numberWithDouble:1] forKey:[[self mediaKeys] objectForKey:key]];
+            [mediaDict setValue:[NSNumber numberWithDouble:1] forKey:[MEDIA_DICT objectForKey:key]];
         }
     }
         

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -9,7 +9,6 @@
 @interface MusicControlManager ()
 
 @property (nonatomic, copy) NSString *artworkUrl;
-@property (nonatomic, strong) NSDictionary *mediaKeys;
 
 @end
 
@@ -22,29 +21,33 @@ NSString * const MEDIA_PLAYBACK_RATE = @"playbackRate";
 RCT_EXPORT_MODULE()
 
 - (NSDictionary *) mediaKeys {
-    if (_mediaKeys == nil) {
-        _mediaKeys = @{
-                @"album": MPMediaItemPropertyAlbumTitle,
-                @"trackCount": MPMediaItemPropertyAlbumTrackCount,
-                @"trackNumber": MPMediaItemPropertyAlbumTrackNumber,
-                @"artist": MPMediaItemPropertyArtist,
-                @"composer": MPMediaItemPropertyComposer,
-                @"discCount": MPMediaItemPropertyDiscCount,
-                @"discNumber": MPMediaItemPropertyDiscNumber,
-                @"genre": MPMediaItemPropertyGenre,
-                @"persistentID": MPMediaItemPropertyPersistentID,
-                @"duration": MPMediaItemPropertyPlaybackDuration,
-                @"title": MPMediaItemPropertyTitle,
-                @"elapsedPlaybackTime": MPNowPlayingInfoPropertyElapsedPlaybackTime,
-                @"playbackRate": MPNowPlayingInfoPropertyPlaybackRate,
-                @"playbackQueueIndex": MPNowPlayingInfoPropertyPlaybackQueueIndex,
-                @"playbackQueueCount": MPNowPlayingInfoPropertyPlaybackQueueCount,
-                @"chapterNumber": MPNowPlayingInfoPropertyChapterNumber,
-                @"chapterCount": MPNowPlayingInfoPropertyChapterCount
-           };
-    }
+    static NSDictionary *dict = nil;
     
-    return _mediaKeys;
+    static dispatch_once_t lock;
+    
+    dispatch_once(&lock, ^{
+        dict = @{
+             @"album": MPMediaItemPropertyAlbumTitle,
+             @"trackCount": MPMediaItemPropertyAlbumTrackCount,
+             @"trackNumber": MPMediaItemPropertyAlbumTrackNumber,
+             @"artist": MPMediaItemPropertyArtist,
+             @"composer": MPMediaItemPropertyComposer,
+             @"discCount": MPMediaItemPropertyDiscCount,
+             @"discNumber": MPMediaItemPropertyDiscNumber,
+             @"genre": MPMediaItemPropertyGenre,
+             @"persistentID": MPMediaItemPropertyPersistentID,
+             @"duration": MPMediaItemPropertyPlaybackDuration,
+             @"title": MPMediaItemPropertyTitle,
+             @"elapsedPlaybackTime": MPNowPlayingInfoPropertyElapsedPlaybackTime,
+             @"playbackRate": MPNowPlayingInfoPropertyPlaybackRate,
+             @"playbackQueueIndex": MPNowPlayingInfoPropertyPlaybackQueueIndex,
+             @"playbackQueueCount": MPNowPlayingInfoPropertyPlaybackQueueCount,
+             @"chapterNumber": MPNowPlayingInfoPropertyChapterNumber,
+             @"chapterCount": MPNowPlayingInfoPropertyChapterCount
+        };
+    });
+    
+    return dict;
 }
 
 - (dispatch_queue_t)methodQueue
@@ -52,13 +55,7 @@ RCT_EXPORT_MODULE()
     return dispatch_get_main_queue();
 }
 
-RCT_EXPORT_METHOD(setPlaying:(NSDictionary *) details)
-{
-    // For backwards compatibility
-    [self updatePlaying:details];
-}
-
-RCT_EXPORT_METHOD(updatePlaying:(NSDictionary *) details)
+RCT_EXPORT_METHOD(updatePlayback:(NSDictionary *) details)
 {
     MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
     
@@ -164,7 +161,7 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
         }
         
         // In iOS Simulator, always include the MPNowPlayingInfoPropertyPlaybackRate key in your nowPlayingInfo dictionary
-        // only if we are creating a new dictionalty
+        // only if we are creating a new dictionary
         if ([key isEqualToString:MEDIA_PLAYBACK_RATE] && [details objectForKey:key] == nil && setDefault) {
             [mediaDict setValue:[NSNumber numberWithDouble:1] forKey:[[self mediaKeys] objectForKey:key]];
         }


### PR DESCRIPTION
#### What's this PR do?
* Changed the `setNowPlaying` to always use a new dictionary.
* Refactored updating of the dictionary using a loop and a keys dictionary. Should do this for the actions too.
* Added `updatePlayback` which updates the current media data with any keys passed in the info object.
* Added `setPlayback` which using `updatePlayback` for backwards compatibility. We can choose to remove this.
* Removed `togglePause` as this is not needed if there is an `updatePlayback` method.

#### Which issue(s) is it related to?
[#36](https://github.com/tanguyantoine/react-native-music-control/issues/36)
[#40](https://github.com/tanguyantoine/react-native-music-control/issues/40)

#### How to test:
* Every time `setNowPlaying` is called it should create a new playback.
* `updatePlayback` should be able to update all known keys

Let me know if I should change anything in here. Also if anything needs to change for the Android and iOS APIs to align.