### PR TITLE
[iOS] Update deprecated methods, fix compiler warnings and missing submodules

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-import { NativeModules, DeviceEventEmitter } from 'react-native';
+import { NativeModules, NativeEventEmitter } from 'react-native';
 const NativeMusicControl = NativeModules.MusicControlManager;
 
 /**
@@ -57,7 +57,7 @@ var MusicControl = {
     if(subscription){
       subscription.remove();
     }
-    subscription = DeviceEventEmitter.addListener(
+    subscription = new NativeEventEmitter(NativeMusicControl).addListener(
       'RNMusicControlEvent',
       (event) => {
         MusicControl.handleCommand(event.name)

--- a/ios/MusicControlManager.h
+++ b/ios/MusicControlManager.h
@@ -1,6 +1,7 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 #import <MediaPlayer/MediaPlayer.h>
 
-@interface MusicControlManager : NSObject <RCTBridgeModule>
+@interface MusicControlManager : RCTEventEmitter <RCTBridgeModule>
 
 @end

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -2,7 +2,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
-#import <AVFoundation/AVAudioSession.h>
+#import <AVFoundation/AVFoundation.h>
 
 @import MediaPlayer;
 
@@ -188,6 +188,7 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
 }
 
 - (id)init {
+  self = [super init];
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioHardwareRouteChanged:) name:AVAudioSessionRouteChangeNotification object:nil];
   return self;
 }
@@ -223,9 +224,13 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
 - (void)onSkipBackward:(MPRemoteCommandEvent*)event { [self sendEvent:@"skipBackward"]; }
 - (void)onSkipForward:(MPRemoteCommandEvent*)event { [self sendEvent:@"skipForward"]; }
 
+- (NSArray<NSString *> *)supportedEvents {
+    return @[@"RNMusicControlEvent"];
+}
+
 - (void)sendEvent:(NSString*)event {
-    [self.bridge.eventDispatcher sendDeviceEventWithName:@"RNMusicControlEvent"
-                                                    body:@{@"name": event}];
+    [self sendEventWithName:@"RNMusicControlEvent"
+                       body:@{@"name": event}];
 }
 
 - (void)updateNowPlayingArtwork


### PR DESCRIPTION
#### What's this PR do?
Replaced deprecated sendDeviceEventWithName with sendEventWithName
Replaced DeviceEventEmmiter with NativeEventEmitter
Resolved compiler warnings and missing submodules

#### Which issue(s) is it related to?

#### Screenshots (if appropriate)

#### How to test: