### PR TITLE
Android synchronize init and destroy

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -81,7 +81,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         return map;
     }
 
-    synchronized public void init() {
+    public void init() {
         if (init) return;
 
         INSTANCE = this;
@@ -159,7 +159,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
     }
 
     @ReactMethod
-    public void setNowPlaying(ReadableMap metadata) {
+    synchronized public void setNowPlaying(ReadableMap metadata) {
         init();
         if(artworkThread != null && artworkThread.isAlive()) artworkThread.interrupt();
 
@@ -240,7 +240,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
     }
 
     @ReactMethod
-    public void updatePlayback(ReadableMap info) {
+    synchronized public void updatePlayback(ReadableMap info) {
         init();
 
         long updateTime;
@@ -280,7 +280,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
     }
 
     @ReactMethod
-    public void resetNowPlaying() {
+    synchronized public void resetNowPlaying() {
         if(!init) return;
         if(artworkThread != null && artworkThread.isAlive()) artworkThread.interrupt();
         artworkThread = null;
@@ -292,7 +292,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
     }
 
     @ReactMethod
-    public void enableControl(String control, boolean enable) {
+    synchronized public void enableControl(String control, boolean enable) {
         init();
 
         long controlValue;

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -81,7 +81,9 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         return map;
     }
 
-    public void init() {
+    synchronized public void init() {
+        if (init) return;
+
         INSTANCE = this;
         ReactApplicationContext context = getReactApplicationContext();
 
@@ -125,7 +127,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         init = true;
     }
 
-    public void destroy() {
+    synchronized public void destroy() {
         if(!init) return;
 
         if (notification != null) notification.hide();
@@ -158,7 +160,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
     @ReactMethod
     public void setNowPlaying(ReadableMap metadata) {
-        if(!init) init();
+        init();
         if(artworkThread != null && artworkThread.isAlive()) artworkThread.interrupt();
 
         String title = metadata.hasKey("title") ? metadata.getString("title") : null;
@@ -239,7 +241,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
     @ReactMethod
     public void updatePlayback(ReadableMap info) {
-        if(!init) init();
+        init();
 
         long updateTime;
         long elapsedTime;
@@ -291,7 +293,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
     @ReactMethod
     public void enableControl(String control, boolean enable) {
-        if(!init) init();
+        init();
 
         long controlValue;
         switch(control) {


### PR DESCRIPTION
#### What's this PR do?

* When `MusicControlModule.onTrimMemory()` is called and almost at the same time 
 `setNowPlaying` or `updatePlayback()` or `enableControl()` is called, 
in `destroy()` many properties become null, but `init()` will not be called because they are called from different threads.
 It will cause NullPointerException.
Example:
``` 
// line 268
state = pb.build();
```

* Fix it by making  `destroy()` and other methods `synchronized`.


#### Which issue(s) is it related to?

#### Screenshots (if appropriate)

#### How to test:
