### PR TITLE
Remove override of 'createJSModules' for RN 0.47

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControl.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControl.java
@@ -19,7 +19,8 @@ public class MusicControl implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
+    // @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
#### What's this PR do?

This updates the library for the react-native 0.47 breaking change.

https://github.com/facebook/react-native/releases/tag/v0.47.0

This is not a breaking change for this library. Users can continue to update react-native-music-control without being forced to update RN to >= 0.47. The downside to doing it this way instead of removing it is that there is now dead code for RN >= 0.47.

#### How to test:

Use in RN 0.47 app, build for android.