### PR TITLE
Artwork Bug Fixes (Issue #46)

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -187,16 +187,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
             rating = RatingCompat.newUnratedRating(ratingType);
         }
 
-        String artwork = null;
-        boolean localArtwork = false;
-        if(metadata.hasKey("artwork")) {
-            if(metadata.getType("artwork") == ReadableType.Map) {
-                artwork = metadata.getMap("artwork").getString("uri");
-                localArtwork = true;
-            } else {
-                artwork = metadata.getString("artwork");
-            }
-        }
+
 
         md.putText(MediaMetadataCompat.METADATA_KEY_TITLE, title);
         md.putText(MediaMetadataCompat.METADATA_KEY_ARTIST, artist);
@@ -212,7 +203,17 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         nb.setContentInfo(album);
         nb.setColor(notificationColor);
 
-        if(artwork != null) {
+        if(metadata.hasKey("artwork")) {
+            String artwork = null;
+            boolean localArtwork = false;
+
+            if(metadata.getType("artwork") == ReadableType.Map) {
+                artwork = metadata.getMap("artwork").getString("uri");
+                localArtwork = true;
+            } else {
+                artwork = metadata.getString("artwork");
+            }
+
             final String artworkUrl = artwork;
             final boolean artworkLocal = localArtwork;
 
@@ -361,7 +362,8 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         Bitmap bitmap = null;
 
         try {
-            if(local) {
+            // If we are running the app in debug mode, the "local" image will be served from htt://localhost:8080, so we need to check for this case and load those images from URL
+            if(local && !url.startsWith("http")) {
 
                 // Gets the drawable from the RN's helper for local resources
                 ResourceDrawableIdHelper helper = ResourceDrawableIdHelper.getInstance();

--- a/index.ios.js
+++ b/index.ios.js
@@ -6,6 +6,7 @@
 
 import { NativeModules, NativeEventEmitter } from 'react-native';
 const NativeMusicControl = NativeModules.MusicControlManager;
+import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 
 /**
  * High-level docs for the MusicControl iOS API can be written here.
@@ -40,7 +41,12 @@ var MusicControl = {
     NativeMusicControl.enableBackgroundMode(enable)
   },
   setNowPlaying: function(info){
-    NativeMusicControl.setNowPlaying(info)
+    // Check if we have an ios asset from react style image require
+    if(info.artwork) {
+        info.artwork = resolveAssetSource(info.artwork) || info.artwork;
+    }
+
+    NativeMusicControl.setNowPlaying(info);
   },
   resetNowPlaying: function(){
     NativeMusicControl.resetNowPlaying()

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -78,12 +78,7 @@ RCT_EXPORT_METHOD(updatePlayback:(NSDictionary *) originalDetails)
 
     center.nowPlayingInfo = [self update:mediaDict with:details andSetDefaults:false];
 
-    // Update the image if it exists
-    if ([details objectForKey:@"artwork"] != nil) {
-        self.artworkUrl = details[@"artwork"];
-    }
-
-    [self updateNowPlayingArtwork];
+  [self updateArtworkIfNeeded:[details objectForKey:@"artwork"]];
 }
 
 
@@ -95,9 +90,7 @@ RCT_EXPORT_METHOD(setNowPlaying:(NSDictionary *) details)
 
     center.nowPlayingInfo = [self update:mediaDict with:details andSetDefaults:true];
 
-    // Custom handling of artwork in another thread, will be loaded async
-    self.artworkUrl = details[@"artwork"];
-    [self updateNowPlayingArtwork];
+  [self updateArtworkIfNeeded:[details objectForKey:@"artwork"]];
 }
 
 RCT_EXPORT_METHOD(resetNowPlaying)
@@ -233,50 +226,64 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
                        body:@{@"name": event}];
 }
 
-- (void)updateNowPlayingArtwork
+- (void)updateArtworkIfNeeded:(id)artwork
 {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-        NSString *url = self.artworkUrl;
-        UIImage *image = nil;
-        // check whether artwork path is present
-        if (![url isEqual: @""]) {
-            // artwork is url download from the interwebs
-            if ([url hasPrefix: @"http://"] || [url hasPrefix: @"https://"]) {
-                NSURL *imageURL = [NSURL URLWithString:url];
-                NSData *imageData = [NSData dataWithContentsOfURL:imageURL];
-                image = [UIImage imageWithData:imageData];
-            } else {
-                // artwork is local. so create it from a UIImage
-                BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:url];
-                if (fileExists) {
-                    image = [UIImage imageNamed:url];
+    NSString *url = nil;
+    if (artwork) {
+        if ([artwork isKindOfClass:[NSString class]]) {
+             url = artwork;
+        } else if ([[artwork valueForKey: @"uri"] isKindOfClass:[NSString class]]) {
+             url = [artwork valueForKey: @"uri"];
+        }
+    }
+
+    if (url != nil) {
+        self.artworkUrl = url;
+
+        // Custom handling of artwork in another thread, will be loaded async
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+            UIImage *image = nil;
+
+            // check whether artwork path is present
+            if (![url isEqual: @""]) {
+                // artwork is url download from the interwebs
+                if ([url hasPrefix: @"http://"] || [url hasPrefix: @"https://"]) {
+                    NSURL *imageURL = [NSURL URLWithString:url];
+                    NSData *imageData = [NSData dataWithContentsOfURL:imageURL];
+                    image = [UIImage imageWithData:imageData];
+                } else {
+                    // artwork is local. so create it from a UIImage
+                    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:url];
+                    if (fileExists) {
+                        image = [UIImage imageNamed:url];
+                    }
                 }
             }
-        }
 
-        // Check if image was available otherwise don't do anything
-        if (image == nil) {
-            return;
-        }
+            // Check if image was available otherwise don't do anything
+            if (image == nil) {
+                return;
+            }
 
-        // check whether image is loaded
-        CGImageRef cgref = [image CGImage];
-        CIImage *cim = [image CIImage];
+            // check whether image is loaded
+            CGImageRef cgref = [image CGImage];
+            CIImage *cim = [image CIImage];
 
-        if (cim != nil || cgref != NULL) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            if (cim != nil || cgref != NULL) {
+                dispatch_async(dispatch_get_main_queue(), ^{
 
-                // Check if URL wasn't changed in the meantime
-                if ([url isEqual:self.artworkUrl]) {
-                    MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
-                    MPMediaItemArtwork *artwork = [[MPMediaItemArtwork alloc] initWithImage: image];
-                    NSMutableDictionary *mediaDict = (center.nowPlayingInfo != nil) ? [[NSMutableDictionary alloc] initWithDictionary: center.nowPlayingInfo] : [NSMutableDictionary dictionary];
-                    [mediaDict setValue:artwork forKey:MPMediaItemPropertyArtwork];
-                    center.nowPlayingInfo = mediaDict;
-                }
-            });
-        }
-    });
+                    // Check if URL wasn't changed in the meantime
+                    if ([url isEqual:self.artworkUrl]) {
+                        MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
+                        MPMediaItemArtwork *artwork = [[MPMediaItemArtwork alloc] initWithImage: image];
+                        NSMutableDictionary *mediaDict = (center.nowPlayingInfo != nil) ? [[NSMutableDictionary alloc] initWithDictionary: center.nowPlayingInfo] : [NSMutableDictionary dictionary];
+                        [mediaDict setValue:artwork forKey:MPMediaItemPropertyArtwork];
+                        center.nowPlayingInfo = mediaDict;
+                    }
+                });
+            }
+        });
+    }
 }
 
 - (void)audioHardwareRouteChanged:(NSNotification *)notification {


### PR DESCRIPTION
#### What's this PR do?
This fixes a bug where a react native app running on the simulator
couldn’t load artwork, the iOS couldn’t load local artwork using the
require statement, and on Android the image was being cleared on every
updatePlayback call, as well as other improvements

#### Which issue(s) is it related to?
Issue #46 

#### How to test:
Artwork needs to be tested locally and remotely on both platforms, and the ability to change out the artwork half way through playback needs to be tested as well.  In my app (which is currently using this code), I initially load dummy artwork and then if there is an internet connection, load the actual artwork after.  That way, if there is not an internet connection, there is still artwork with basic branding.