### PR TITLE
fix: only update image if it doesn't exist

### DIFF
--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -77,13 +77,13 @@ RCT_EXPORT_METHOD(updatePlayback:(NSDictionary *) originalDetails)
     NSMutableDictionary *mediaDict = [[NSMutableDictionary alloc] initWithDictionary: center.nowPlayingInfo];
 
     center.nowPlayingInfo = [self update:mediaDict with:details andSetDefaults:false];
-
-    // Update the image if it doesn't exists
-    if ([details objectForKey:@"artwork"] == nil) {
+    
+    // Update the image if only it it differs from the previous image
+    
+    if ([details objectForKey:@"artwork"] != self.artworkUrl) {
         self.artworkUrl = details[@"artwork"];
+        [self updateNowPlayingArtwork];
     }
-      [self updateNowPlayingArtwork];
-
 
 }
 

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -78,12 +78,13 @@ RCT_EXPORT_METHOD(updatePlayback:(NSDictionary *) originalDetails)
 
     center.nowPlayingInfo = [self update:mediaDict with:details andSetDefaults:false];
 
-    // Update the image if it exists
-    if ([details objectForKey:@"artwork"] != nil) {
+    // Update the image if it doesn't exists
+    if ([details objectForKey:@"artwork"] == nil) {
         self.artworkUrl = details[@"artwork"];
     }
+      [self updateNowPlayingArtwork];
 
-    [self updateNowPlayingArtwork];
+
 }
 
 


### PR DESCRIPTION
#### What's this PR do?
Only set a new artwork url if it didn't previously exist - iOS fix only 

#### Which issue(s) is it related to?
updatePlayback function was updating the image every time it was called which was causing memory leaks

