### PR TITLE
Multiple options for Swipe-to-close on Android Notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ Important Notes:
 * The interval value only changes what number displays in the UI, the actual logic to skip forward or backward by a given amount must be implemented in the appropriate callbacks
 * When using [react-native-sound](https://github.com/zmxv/react-native-sound) for audio playback, make sure that on iOS `mixWithOthers` is set to `false` in [`Sound.setCategory(value, mixWithOthers)`](https://github.com/zmxv/react-native-sound#soundsetcategoryvalue-mixwithothers-ios-only). MusicControl will not work on a real device when this is set to `true`.
 
+There is also a `closeNotification` control on Android controls the swipe behavior of the audio playing notification, and accepts additional configuration options with the `when` key:
+
+```javascript
+// Always allow user to close notification on swipe
+MusicControl.enableControl('closeNotification', true, {when: 'always'})
+
+// Default - Allow user to close notification on swipe when audio is paused
+MusicControl.enableControl('closeNotification', true, {when: 'paused'})
+
+// Never allow user to close notification on swipe
+MusicControl.enableControl('closeNotification', true, {when: 'never'})
+```
+
 ### Register to events
 
 ```javascript
@@ -245,6 +258,11 @@ componentDidMount() {
     MusicControl.on('disableLanguageOption', ()=> {}); // iOS only
     MusicControl.on('skipForward', ()=> {});
     MusicControl.on('skipBackward', ()=> {});
+
+    // Android Only
+    MusicControl.on('closeNotification', ()=> {
+      this.props.dispatch(onAudioEnd());
+    })
 }
 ```
 

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlReceiver.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlReceiver.java
@@ -4,15 +4,21 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.view.KeyEvent;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 public class MusicControlReceiver extends BroadcastReceiver {
 
     private final MusicControlModule module;
     private final String packageName;
+    private final ReactApplicationContext reactContext;
 
-    public MusicControlReceiver(MusicControlModule module, String packageName) {
+    public MusicControlReceiver(MusicControlModule module, ReactApplicationContext context) {
         this.module = module;
-        this.packageName = packageName;
+        this.packageName = context.getPackageName();
+        this.reactContext = context;
     }
 
     @Override
@@ -27,6 +33,11 @@ public class MusicControlReceiver extends BroadcastReceiver {
             // Removes the notification and deactivates the media session
             module.notification.hide();
             module.session.setActive(false);
+
+            // Notify react native
+            WritableMap data = Arguments.createMap();
+            data.putString("name", "closeNotification");
+            reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit("RNMusicControlEvent", data);
 
         } else if(MusicControlNotification.MEDIA_BUTTON.equals(action) || Intent.ACTION_MEDIA_BUTTON.equals(action)) {
 


### PR DESCRIPTION
#### What's this PR do?

Now the app developer can specify whether the Android audio notification will always
close on swipe, only close if the audio is paused, or will never close
when swiped.  In addition, a new control was added to provide a
callback for when it is closed via swipe, so that the app developer can
choose to terminate the audio or do nothing.

#### Which issue(s) is it related to?

None, it is a convenience feature that other developers may find useful.

#### How to test:

Run on device, enable the closeNotification control, optionally pass in a 'when' qualifier option, and try closing the notification.  If it is allowed to be closed, it should call the enabled callback on notification close, so that the app can react appropriately.