### PR TITLE
File Reading Refactoring

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -214,9 +214,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
                 localArtwork = true;
             } else {
                 artwork = metadata.getString("artwork");
-                if(!(artwork.startsWith("http://") || artwork.startsWith("https://"))){
-                    localArtwork = true;
-                }
+                localArtwork = !artwork.startsWith("http://") && !artwork.startsWith("https://");
             }
 
             final String artworkUrl = artwork;

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -214,6 +214,9 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
                 localArtwork = true;
             } else {
                 artwork = metadata.getString("artwork");
+                if(!(artwork.startsWith("http://") || artwork.startsWith("https://"))){
+                    localArtwork = true;
+                }
             }
 
             final String artworkUrl = artwork;

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -258,10 +258,7 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
                     image = [UIImage imageWithData:imageData];
                 } else {
                     // artwork is local. so create it from a UIImage
-                    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:url];
-                    if (fileExists) {
-                        image = [UIImage imageNamed:url];
-                    }
+                    image = [UIImage imageNamed:url];                    
                 }
             }
 


### PR DESCRIPTION
`Description:`
In iOS, when trying to read a local-file, we are not able to use the method `fileExistsAtPath`
See `Anton Tropashko's` answer in the following url - https://stackoverflow.com/questions/9303875/fileexistsatpath-returning-no-for-files-that-exist

In Android, you can only read files which are `url` or `{uri: path}`.

`Changes:`
* iOS - Removed `fileExistsAtPath`, if there's a file in the `Xcode's image assets`, then it will load it in `UIImage`. Even if there is no such file, then it will contain `null`, no crashes will occur.
* Android - Added an option to read files as a path, and not only as `{uri: path}`.
 
`How to test:`
* iOS - Add an image to `Images.xcassets`.
* Android - Add an image to `res` folder.

-  In `MusicControl.setNowPlaying` set `artwork: <file_name>`.