### PR TITLE
skip backward default button default erroneously left out a 10 in the…

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -67,7 +67,7 @@ public class MusicControlNotification {
         if (options != null && options.containsKey("skipBackward") && (options.get("skipBackward") == 10 || options.get("skipBackward") == 5 || options.get("skipBackward") == 30)) {
             skipBackward = createAction("skip_backward_" + options.get("skipBackward").toString(), "Skip Backward", mask, PlaybackStateCompat.ACTION_REWIND, skipBackward);
         } else {
-            skipBackward = createAction("skip_backward_", "Skip Backward", mask, PlaybackStateCompat.ACTION_REWIND, skipBackward);
+            skipBackward = createAction("skip_backward_10", "Skip Backward", mask, PlaybackStateCompat.ACTION_REWIND, skipBackward);
         }
     }
 


### PR DESCRIPTION
The default SkipBackward icon left off the number of seconds so no icon appears by default on android. This PR fixes the issue by setting the default icon to 10 seconds (like it is for SkipForward).