### PR TITLE
allow changing playback position by dragging slider on ios lock screen

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -54,9 +54,9 @@ var MusicControl = {
   enableControl: function(controlName, bool, options = {}){
     NativeMusicControl.enableControl(controlName, bool, options || {})
   },
-  handleCommand: function(commandName){
+  handleCommand: function(commandName, value){
     if(handlers[commandName]){
-      handlers[commandName]()
+      handlers[commandName](value)
     }
   },
   on: function(actionName, cb){
@@ -66,7 +66,7 @@ var MusicControl = {
     subscription = new NativeEventEmitter(NativeMusicControl).addListener(
       'RNMusicControlEvent',
       (event) => {
-        MusicControl.handleCommand(event.name)
+        MusicControl.handleCommand(event.name, event.value)
       }
     );
     handlers[actionName] = cb

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -114,6 +114,9 @@ RCT_EXPORT_METHOD(enableControl:(NSString *) controlName enabled:(BOOL) enabled 
     } else if ([controlName isEqual: @"play"]) {
         [self toggleHandler:remoteCenter.playCommand withSelector:@selector(onPlay:) enabled:enabled];
 
+    } else if ([controlName isEqual: @"changePlaybackPosition"]) {
+        [self toggleHandler:remoteCenter.changePlaybackPositionCommand withSelector:@selector(onChangePlaybackPosition:) enabled:enabled];
+
     } else if ([controlName isEqual: @"stop"]) {
         [self toggleHandler:remoteCenter.stopCommand withSelector:@selector(onStop:) enabled:enabled];
 
@@ -195,6 +198,7 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
     MPRemoteCommandCenter *remoteCenter = [MPRemoteCommandCenter sharedCommandCenter];
     [self toggleHandler:remoteCenter.pauseCommand withSelector:@selector(onPause:) enabled:false];
     [self toggleHandler:remoteCenter.playCommand withSelector:@selector(onPlay:) enabled:false];
+    [self toggleHandler:remoteCenter.changePlaybackPositionCommand withSelector:@selector(onChangePlaybackPosition:) enabled:false];
     [self toggleHandler:remoteCenter.stopCommand withSelector:@selector(onStop:) enabled:false];
     [self toggleHandler:remoteCenter.togglePlayPauseCommand withSelector:@selector(onTogglePlayPause:) enabled:false];
     [self toggleHandler:remoteCenter.enableLanguageOptionCommand withSelector:@selector(onEnableLanguageOption:) enabled:false];
@@ -211,6 +215,7 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
 
 - (void)onPause:(MPRemoteCommandEvent*)event { [self sendEvent:@"pause"]; }
 - (void)onPlay:(MPRemoteCommandEvent*)event { [self sendEvent:@"play"]; }
+- (void)onChangePlaybackPosition:(MPChangePlaybackPositionCommandEvent*)event { [self sendEventWithValue:@"changePlaybackPosition" withValue:[NSString stringWithFormat:@"%.15f", event.positionTime]]; }
 - (void)onStop:(MPRemoteCommandEvent*)event { [self sendEvent:@"stop"]; }
 - (void)onTogglePlayPause:(MPRemoteCommandEvent*)event { [self sendEvent:@"togglePlayPause"]; }
 - (void)onEnableLanguageOption:(MPRemoteCommandEvent*)event { [self sendEvent:@"enableLanguageOption"]; }
@@ -229,6 +234,10 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
 - (void)sendEvent:(NSString*)event {
     [self sendEventWithName:@"RNMusicControlEvent"
                        body:@{@"name": event}];
+}
+
+- (void)sendEventWithValue:(NSString*)event withValue:(NSString*)value{
+   [self sendEventWithName:@"RNMusicControlEvent" body:@{@"name": event, @"value":value}];
 }
 
 - (void)updateArtworkIfNeeded:(id)artwork


### PR DESCRIPTION
This PR resolves issue #107, it allows you to change the playback position by dragging the slider on the iOS lock screen. Here is a gif of the functionality: 
![demo change playback position](https://user-images.githubusercontent.com/7813619/32823348-7febe734-c9a2-11e7-9b1c-9311264e7327.gif)

Tested on a real device (iPhone 6s) and the iPhone 7 simulator.
