### PR TITLE
do not overwrite artwork url with nil when using the updatePlayback c…

### DIFF
--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -80,7 +80,6 @@ RCT_EXPORT_METHOD(updatePlayback:(NSDictionary *) originalDetails)
 
 
     if ([details objectForKey:@"artwork"] != self.artworkUrl) {
-        self.artworkUrl = details[@"artwork"];
         [self updateArtworkIfNeeded:[details objectForKey:@"artwork"]];
     }
 


### PR DESCRIPTION
Fixes issue #109, the updateArtworkIfNeeded function already updates self.artworkUrl if url is not nil, this line is redundant when details[@"artwork"] is not nil, and incorrectly overwrites self.artworkUrl with nil if updatePlayback is called without specifying an artwork url. Tested on iPhone 6s real device and iPhone 7 simulator. You can see correctly functioning artwork in this gif: 
![demo change playback position](https://user-images.githubusercontent.com/7813619/32823966-a9500932-c9a4-11e7-8027-b24b1a2f1474.gif)
