### PR TITLE
Pause on audio session interruption events on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ componentDidMount() {
       this.props.dispatch(playRemoteControl());
     })
 
-    // on iOS this event will also be triggered by the audio router change event.
-    // This happens when headphones are unplugged or a bluetooth audio peripheral disconnects from the device
+    // on iOS this event will also be triggered by interruptions (incoming calls) and audio router change events
+    // happening when headphones are unplugged or a bluetooth audio peripheral disconnects from the device
     MusicControl.on('pause', ()=> {
       this.props.dispatch(pauseRemoteControl());
     })

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -190,6 +190,7 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
 - (id)init {
   self = [super init];
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioHardwareRouteChanged:) name:AVAudioSessionRouteChangeNotification object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioInterrupted:) name:AVAudioSessionInterruptionNotification object:nil];
   return self;
 }
 
@@ -209,6 +210,7 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
     [self toggleHandler:remoteCenter.skipBackwardCommand withSelector:@selector(onSkipBackward:) enabled:false];
     [self toggleHandler:remoteCenter.skipForwardCommand withSelector:@selector(onSkipForward:) enabled:false];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:AVAudioSessionRouteChangeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:AVAudioSessionInterruptionNotification object:nil];
 }
 
 
@@ -303,6 +305,14 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
     NSInteger routeChangeReason = [notification.userInfo[AVAudioSessionRouteChangeReasonKey] integerValue];
     if (routeChangeReason == AVAudioSessionRouteChangeReasonOldDeviceUnavailable) {
         //headphones unplugged or bluetooth device disconnected, iOS will pause audio
+        [self sendEvent:@"pause"];
+    }
+}
+
+- (void)audioInterrupted:(NSNotification *)notification {
+    NSInteger interuptionType = [notification.userInfo[AVAudioSessionInterruptionTypeKey] integerValue];
+    if (interuptionType == AVAudioSessionInterruptionTypeBegan) {
+        // Playback interrupted by an incoming phone call.
         [self sendEvent:@"pause"];
     }
 }


### PR DESCRIPTION
#### What's this PR do?

Pauses playback on iOS when an [audio interruption](https://developer.apple.com/library/content/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/HandlingAudioInterruptions/HandlingAudioInterruptions.html) event is received.

#### Which issue(s) is it related to?

None.

#### Screenshots (if appropriate)

N/A

#### How to test:

1. Start playback.
1. Initiate a phone call to the device.
1. Observe the `pause` event.