### PR TITLE
add end interruption should resume functionality for ios and fix typo

### DIFF
--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -315,6 +315,13 @@ RCT_EXPORT_METHOD(enableBackgroundMode:(BOOL) enabled){
         // Playback interrupted by an incoming phone call.
         [self sendEvent:@"pause"];
     }
+    if (interruptionType == AVAudioSessionInterruptionTypeEnded) {
+        // if 
+        NSInteger shouldResume = [notification.userInfo[AVAudioSessionInterruptionOptionKey] unsignedIntegerValue];
+        if (shouldResume == AVAudioSessionInterruptionOptionShouldResume) {
+          [self sendEvent:@"play"];
+        }
+    }
 }
 
 @end


### PR DESCRIPTION
This pull request adds functionality to resume playback when AVAudioSessionInterruptionOptionShouldResume is set to true. Tested on iPhone 6s.