### PR TITLE
Better handle audio session interruptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,14 @@ MusicControl.enableControl('closeNotification', true, {when: 'never'})
 componentDidMount() {
     MusicControl.enableBackgroundMode(true);
 
+    // on iOS, pause playback during audio interruptions (incoming calls) and resume afterwards.
+    MusicControl.handleAudioInterruptions(true);
+
     MusicControl.on('play', ()=> {
       this.props.dispatch(playRemoteControl());
     })
 
-    // on iOS this event will also be triggered by interruptions (incoming calls) and audio router change events
+    // on iOS this event will also be triggered by audio router change events
     // happening when headphones are unplugged or a bluetooth audio peripheral disconnects from the device
     MusicControl.on('pause', ()=> {
       this.props.dispatch(pauseRemoteControl());

--- a/index.d.ts
+++ b/index.d.ts
@@ -113,4 +113,11 @@ export default class MusicControl {
      * Keep in mind that just like with music_control_icon the resource specified has to be in the drawable package of your Android app.
      */
     // static setCustomNotificationIcon(path: string): void
+
+    /**
+     * Switch audio interruption handling.
+     * When handling is enabled, playback will be paused when application gets interrupted, and resumed after the interruption.
+     * @param enable
+     */
+    static handleAudioInterruptions(enable: boolean): void
 }

--- a/index.js
+++ b/index.js
@@ -84,7 +84,14 @@ const MusicControl = {
     subscription = null;
     handlers = {};
     NativeMusicControl.stopControl();
-  }
+  },
+  handleAudioInterruptions: function(enable){
+    if (IS_ANDROID) {
+      console.log("Audio interruption handling not implemented for Android");
+    } else {
+      NativeMusicControl.observeAudioInterruptions(enable);
+    }
+  },
 };
 
 export default MusicControl;


### PR DESCRIPTION
#### What's this PR do?

* Adds a handleAudioInterruptions() method which enables interruption handling;
* Resumes playback on "interruption ended" messages on iOS.

#### Which issue(s) is it related to?

This has been requested by @DanNi0130 in #117.

#### Screenshots (if appropriate)

N/A

#### How to test:

* Use library as usual: audio interruptions are not handled
* Call `MusicControl.handleAudioInterruptions(true)`: playback is paused on audio interruptions and resumed afterwards (iOS only).