### PR TITLE
Add requiresMainQueueSetup for RN 0.51

### DIFF
--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -205,10 +205,15 @@ RCT_EXPORT_METHOD(observeAudioInterruptions:(BOOL) observe){
 }
 
 - (id)init {
-  self = [super init];
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioHardwareRouteChanged:) name:AVAudioSessionRouteChangeNotification object:nil];
-  self.audioInterruptionsObserved = false;
-  return self;
+    self = [super init];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioHardwareRouteChanged:) name:AVAudioSessionRouteChangeNotification object:nil];
+    self.audioInterruptionsObserved = false;
+    return self;
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
 }
 
 - (void)dealloc {


### PR DESCRIPTION
#### What's this PR do?
Setup requiresMainQueueSetup for React Native 0.51.0

#### Which issue(s) is it related to?
Fix for #125 

