### PR TITLE
Fixed typescript definition errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,11 +29,11 @@ export default class MusicControl {
     /**
      * Define state status.
      */
-    static STATE_PLAYING: NativeMusicControl //  Playing. Ex: when playing audio again.
-    static STATE_PAUSED: NativeMusicControl // Paused
-    static STATE_ERROR: NativeMusicControl // Error
-    static STATE_STOPPED: NativeMusicControl // Stopped
-    static STATE_BUFFERING: NativeMusicControl // Buffering
+    static STATE_PLAYING: string //  Playing. Ex: when playing audio again.
+    static STATE_PAUSED: string // Paused
+    static STATE_ERROR: string // Error
+    static STATE_STOPPED: string // Stopped
+    static STATE_BUFFERING: string // Buffering
 
     // Rating is not supported on iOS. This is kept here for compatibility
     // static RATING_HEART: 0;


### PR DESCRIPTION
When compiling typescript I get the following warnings. Not sure where `NativeMusicControl` comes from but I think these can just be `string` instead?

```
..../node_modules/react-native-music-control/index.d.ts(36,29): error TS2304: Cannot find name 'NativeMusicControl'.
```
