### PR TITLE
Ios local fix

### DIFF
--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -300,10 +300,10 @@ RCT_EXPORT_METHOD(observeAudioInterruptions:(BOOL) observe){
                     NSData *imageData = [NSData dataWithContentsOfURL:imageURL];
                     image = [UIImage imageWithData:imageData];
                 } else {
-                    // artwork is local. so create it from a UIImage
-                    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:artworkUrl];
+                    NSString *localArtworkUrl = [artworkUrl stringByReplacingOccurrencesOfString:@"file://" withString:@""];
+                    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:localArtworkUrl];
                     if (fileExists) {
-                        image = [UIImage imageNamed:artworkUrl];
+                        image = [UIImage imageNamed:localArtworkUrl];
                     }
                 }
             }

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -80,7 +80,7 @@ RCT_EXPORT_METHOD(updatePlayback:(NSDictionary *) originalDetails)
     center.nowPlayingInfo = [self update:mediaDict with:details andSetDefaults:false];
 
     NSString *artworkUrl = [self getArtworkUrl:[originalDetails objectForKey:@"artwork"]];
-    if (artworkUrl != self.artworkUrl) {
+    if (artworkUrl != self.artworkUrl && artworkUrl != nil) {
         self.artworkUrl = artworkUrl;
         [self updateArtworkIfNeeded:artworkUrl];
     }


### PR DESCRIPTION
This fixes #146.

You can find the full details there, but in short, some change in RN broke local iOS artwork by using a new scheme for files, and this change accommodates for that and restores iOS local artwork functionality.