### PR TITLE
Using checking for value equality of artworkUrl...

### DIFF
--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -80,7 +80,7 @@ RCT_EXPORT_METHOD(updatePlayback:(NSDictionary *) originalDetails)
     center.nowPlayingInfo = [self update:mediaDict with:details andSetDefaults:false];
 
     NSString *artworkUrl = [self getArtworkUrl:[originalDetails objectForKey:@"artwork"]];
-    if (artworkUrl != self.artworkUrl && artworkUrl != nil) {
+    if (![artworkUrl isEqualToString:self.artworkUrl] && artworkUrl != nil) {
         self.artworkUrl = artworkUrl;
         [self updateArtworkIfNeeded:artworkUrl];
     }


### PR DESCRIPTION
... to prevent continually fetching artwork images

#### What's this PR do?
Checks for value equality of `artworkUrl` to prevent. 

#### Which issue(s) is it related to?
The same artwork is being continually fetched when the same `artwork` is being passed to `updatePlayback:`

#### Screenshots (if appropriate)

#### How to test:
Check that `updateArtworkIfNeeded:` is not called twice for the same URL.