### PR TITLE
fix for custom notification style crash on huawei devices (#148)

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class MusicControlModule extends ReactContextBaseJavaModule implements ComponentCallbacks2 {
@@ -140,7 +141,10 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
             createChannel(context);
         }
         nb = new NotificationCompat.Builder(context, CHANNEL_ID);
-        nb.setStyle(new MediaStyle().setMediaSession(session.getSessionToken()));
+
+        if (!(Build.MANUFACTURER.toLowerCase(Locale.getDefault()).contains("huawei") && Build.VERSION.SDK_INT < Build.VERSION_CODES.M)) {
+            nb.setStyle(new MediaStyle().setMediaSession(session.getSessionToken()));
+        }
 
         state = pb.build();
 


### PR DESCRIPTION
#### What's this PR does?
Fixes remoteView notification style issue on huawei devices

#### Which issue(s) is it related to?
https://github.com/tanguyantoine/react-native-music-control/issues/148

#### Screenshots (if appropriate)

#### How to test:
Check notification on a huawei device when music is playing, should crash without this fix