### PR TITLE
stopForeground service onTaskRemoved in MusicControlNotification

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
           package="com.tanguyantoine.react">
 
     <application>
-        <service android:stopWithTask="false" android:name=".MusicControlNotification$NotificationService" />
+        <service android:stopWithTask="true" android:name=".MusicControlNotification$NotificationService" />
     </application>
 
 </manifest>

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -202,6 +202,9 @@ public class MusicControlNotification {
             if(MusicControlModule.INSTANCE != null) {
                 MusicControlModule.INSTANCE.destroy();
             }
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                stopForeground(true);
+            }
             stopSelf(); // Stop the service as we won't need it anymore
         }
 


### PR DESCRIPTION
#### What's this PR does?
stopForeground service in android > 8.0

#### Which issue(s) is it related to?
Service would not be shut down properly when app was closed. This caused the app to keep running causing all kinds of crashes.

Foreground services are not always closed on stopSelf()
[https://developer.android.com/guide/components/services#Foreground](https://developer.android.com/guide/components/services#Foreground)

> To remove the service from the foreground, call stopForeground(). This method takes a boolean, which indicates whether to remove the status bar notification as well. This method does not stop the service. However, if you stop the service while it's still running in the foreground, the notification is also removed.

#### How to test:
Using 0.9.6 and android 8.0 shut down the app whilst some audio is active and the notification controls are present. For me the app doesn't shut down and when restarting the app startup scripts are not run and so forth. 

Using following changes the app closes properly