### PR TITLE
notification not dismissing because of foreground service on android O and above

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -161,12 +161,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
         Intent myIntent = new Intent(context, MusicControlNotification.NotificationService.class);
 
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
-            context.startForegroundService(myIntent);
-
-        }
-        else
-            context.startService(myIntent);
+        context.startService(myIntent);
 
         context.registerComponentCallbacks(this);
 

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -182,16 +182,6 @@ public class MusicControlNotification {
         }
 
         @Override
-        public void onCreate() {
-            super.onCreate();
-
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                Notification notification = MusicControlModule.INSTANCE.notification.prepareNotification(MusicControlModule.INSTANCE.nb,false);
-                startForeground(NOTIFICATION_ID, notification);
-            }
-        }
-
-        @Override
         public int onStartCommand(Intent intent, int flags, int startId) {
             return START_NOT_STICKY;
         }
@@ -201,9 +191,6 @@ public class MusicControlNotification {
             // Destroy the notification and sessions when the task is removed (closed, killed, etc)
             if(MusicControlModule.INSTANCE != null) {
                 MusicControlModule.INSTANCE.destroy();
-            }
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                stopForeground(true);
             }
             stopSelf(); // Stop the service as we won't need it anymore
         }


### PR DESCRIPTION
#### What's this PR does?
It solves two key issues:
1. On android versions >= Oreo, **foreground service is causing the notification to become non-dismissable**, this happens only for the first notification post-initialization because from the second notification, normal NotificationManagerCompat way is used. It is a very bad experience because user won't be able to dismiss the notification unless he kills your app, which most users are unaware of, and they may incidentally end up uninstalling the app.
2. Because of foreground service, **an ugly white empty notification is created even when one is not configured** which is again non-dismissable and non-actionable because there's no way I can stop the foregroundService there.

#### Which issue(s) is it related to?
I didn't find any issues in the issue list (because I saw that it is due to a fairly recent change), but since this is very critical for our user base, instead of creating one, raising a PR.

#### Screenshots (if appropriate)
![screenshot_20190111-182959](https://user-images.githubusercontent.com/40559524/51035192-30a45380-15cf-11e9-8136-24a2a207486a.jpg)
![screenshot_20190111-182942](https://user-images.githubusercontent.com/40559524/51035194-326e1700-15cf-11e9-89f9-b10b87617d7b.jpg)
![screenshot_20190111-182948](https://user-images.githubusercontent.com/40559524/51035196-339f4400-15cf-11e9-9b22-1605b325874a.jpg)


#### How to test:
on any android device running android O or above, follow the steps:
1. Force kill the app.
2. Open the app, play any video with NotificationClose param as "always" or "paused"
3. Now these should make the notification dismissable at least in the paused state, try dismissing the notification.