### PR TITLE
fix: remove extra pause event related to app suspension in IOS10+

### DIFF
--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -370,8 +370,9 @@ RCT_EXPORT_METHOD(observeAudioInterruptions:(BOOL) observe){
     }
     NSInteger interruptionType = [notification.userInfo[AVAudioSessionInterruptionTypeKey] integerValue];
     NSInteger interruptionOption = [notification.userInfo[AVAudioSessionInterruptionOptionKey] integerValue];
-
-    if (interruptionType == AVAudioSessionInterruptionTypeBegan) {
+    bool delayedSuspendedNotification = (@available(iOS 10.0, *)) && [notification.userInfo[AVAudioSessionInterruptionWasSuspendedKey] boolValue];
+    
+    if (interruptionType == AVAudioSessionInterruptionTypeBegan && !delayedSuspendedNotification) {
         // Playback interrupted by an incoming phone call.
         [self sendEvent:@"pause"];
     }


### PR DESCRIPTION
#### What's this PR does?
Apparently starting in IOS10, the OS now sends a 'Suspended' notification AFTER
an app that was suspended is resumed. The IOS implementation used to deliver this notification as a 'pause' event, which does not correspond to a user behavior. By checking for the new field on the suspended notification, I am able to suppress the false pause event from being fired to JS.

#### Which issue(s) is it related to?
See this note here for details on the Notification change in IOS10+: https://developer.apple.com/documentation/avfoundation/avaudiosession/1616596-interruptionnotification

#### Screenshots (if appropriate)
NA
#### How to test:
1) Setup an app with lock screen controls AND the following settings on IOS10+
```
    MusicControl.enableBackgroundMode(true);
    MusicControl.handleAudioInterruptions(true);
    MusicControl.on('play', this.play.bind(this));
    MusicControl.on('pause', this.pause.bind(this));
``
2) Play a track, trigger the lock screen, and pause the app.
3) Let the lock screen sleep (which seems to reliably trigger an app suspension for me).
4) wake the phone and select Play on the lock screen.
5) Before this change, a Play will fire, followed by an unwanted Pause event. By adding this change, teh Pause event will no longer fire, satisfying the desired user behavior.