### PR TITLE
fix controls not showing on Android lock screen

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -141,9 +141,13 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
             createChannel(context);
         }
         nb = new NotificationCompat.Builder(context, CHANNEL_ID);
+        nb.setVisibility(Notification.VISIBILITY_PUBLIC);
 
         if (!(Build.MANUFACTURER.toLowerCase(Locale.getDefault()).contains("huawei") && Build.VERSION.SDK_INT < Build.VERSION_CODES.M)) {
-            nb.setStyle(new MediaStyle().setMediaSession(session.getSessionToken()));
+            MediaStyle style = new MediaStyle();
+            style.setMediaSession(session.getSessionToken());
+            style.setShowActionsInCompactView(new int[]{0,1,2});
+            nb.setStyle(style);
         }
 
         state = pb.build();


### PR DESCRIPTION
Fixes an issue where controls wouldn't show on the lock screen on Android ( Issue #192 )