### PR TITLE
Add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 lib/
 .envrc
 .npmrc
+package-lock.json


### PR DESCRIPTION
#### What this PR does
Adds `package-lock.json` to `.gitignore`. So if you're like me and accidentally run `npm install` instead of `yarn install`, it won't add this file.