### PR TITLE
Fix media center info in iOS 12

### DIFF
--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -229,6 +229,7 @@ RCT_EXPORT_METHOD(observeAudioInterruptions:(BOOL) observe){
 - (id)init {
     self = [super init];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioHardwareRouteChanged:) name:AVAudioSessionRouteChangeNotification object:nil];
+    [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
     self.audioInterruptionsObserved = false;
     return self;
 }


### PR DESCRIPTION
#### What's this PR does?

Updates the playback state using `:setPlaybackState` added in iOS 11. Starting in iOS 12 (I think), playback state stopped getting updated unless this method was used. Previous versions of iOS are left unchanged.

The second commit is a minor fix for an extreme edge case, but is good practice. `beginReceivingRemoteControlEvents` must be called by at least one app on the device, but all apps needing remote events should call it. You'd likely never notice an issue, but I ran into it on a new device.

#### Which issue(s) is it related to?

Fixes gh-242

#### How to test:

For the first commit, include in a demo project and update playback state.

The second commit is really hard to test, but it doesn't hurt to have it.