### PR TITLE
[bug][Android] Add a bit more thread safety + fuller shutdown

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -179,7 +179,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
     }
 
     @ReactMethod
-    public void stopControl() {
+    public synchronized void stopControl() {
         if (!init)
             return;
 

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -80,9 +80,12 @@ public class MusicControlNotification {
         }
     }
 
-    public Notification prepareNotification(NotificationCompat.Builder builder, boolean isPlaying) {
+    /**
+     * NOTE: Synchronized since the NotificationService called prepare without a re-entrant lock.
+     *       Other call sites (e.g. show/hide in module) are already synchronized.
+     */
+    public synchronized Notification prepareNotification(NotificationCompat.Builder builder, boolean isPlaying) {
         // Add the buttons
-
 
         builder.mActions.clear();
         if (previous != null) builder.addAction(previous);
@@ -226,9 +229,16 @@ public class MusicControlNotification {
         @Override
         public void onDestroy() {
             isRunning = false;
+
+            if (MusicControlModule.INSTANCE != null) {
+                MusicControlModule.INSTANCE.destroy();
+            }
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 stopForeground(true);
             }
+
+            stopSelf();
         }
     }
 }


### PR DESCRIPTION
- synchronizing the prepareNotification function since it can be called in some cases from NotificationService.onCreate in a non thread safe manner
- making sure that the notification shuts down properly if the NotificationService is destroyed