### PR TITLE
fix(package.json): remove unused rnpm object to fix warning in RN 0.60

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "test": "echo 'no tests'",
     "semantic-release:ci": "semantic-release --no-ci"
   },
-  "rnpm": {},
   "devDependencies": {
     "@semantic-release/changelog": "^3.0.2",
     "@semantic-release/git": "^7.0.7",


### PR DESCRIPTION
#### What's this PR does?

Removes `rnpm` from package.json.

#### Which issue(s) is it related to?

None opened

#### How to test:

Install and `react-native link react-native-music-control` with RN 0.60.
