### PR TITLE
fix(android): migrate support libraries to androidx

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,6 @@ repositories {
 
 dependencies {
     compileOnly 'com.facebook.react:react-native:+'
-    implementation "com.android.support:support-media-compat:${safeExtGet('supportLibVersion', '26.+')}"
+    implementation 'androidx.core:core:1.0.2'
+    implementation 'androidx.media:media:1.0.1'
 }

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
@@ -2,11 +2,10 @@ package com.tanguyantoine.react;
 
 import android.content.Intent;
 import android.os.Build;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -14,13 +14,13 @@ import android.graphics.drawable.Drawable;
 import android.media.AudioManager;
 import android.os.SystemClock;
 import android.os.Build;
-import android.support.annotation.RequiresApi;
+import androidx.annotation.RequiresApi;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.media.app.NotificationCompat.MediaStyle;
+import androidx.core.app.NotificationCompat;
+import androidx.media.app.NotificationCompat.MediaStyle;
 import android.util.Log;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -170,7 +170,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
             createChannel(context);
         }
         nb = new NotificationCompat.Builder(context, CHANNEL_ID);
-        nb.setVisibility(Notification.VISIBILITY_PUBLIC);
+        nb.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
 
         updateNotificationMediaStyle();
 

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -10,16 +10,16 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.IBinder;
-import android.support.v4.app.NotificationManagerCompat;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
-import android.support.v4.app.NotificationCompat;
 import android.view.KeyEvent;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
 
 import java.util.Map;
 
-import static android.support.v4.app.NotificationCompat.PRIORITY_MIN;
+import static androidx.core.app.NotificationCompat.PRIORITY_MIN;
 import static com.tanguyantoine.react.MusicControlModule.CHANNEL_ID;
 import static com.tanguyantoine.react.MusicControlModule.NOTIFICATION_ID;
 

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlVolumeListener.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlVolumeListener.java
@@ -1,6 +1,6 @@
 package com.tanguyantoine.react;
 
-import android.support.v4.media.VolumeProviderCompat;
+import androidx.media.VolumeProviderCompat;
 import com.facebook.react.bridge.ReactApplicationContext;
 
 public class MusicControlVolumeListener extends VolumeProviderCompat {


### PR DESCRIPTION
#### What's this PR does?

This fixes compilation with RN 0.60.

It's probably worth adding a note to the installation guide about not mixing the old Android support library and Androidx in the same project. Either everything needs to be upgraded to Androidx or everything needs to be downgraded to the support library. More and more people will become familiar with this process as they upgrade react native to 0.60.

I *think* this means that the release of react-native-music-control that includes this PR will require RN >= 0.60. However, it's possible that one could use the reverse [jetifier](https://github.com/mikehardy/jetifier) to convert this library back to the old support library, but I haven't tried that. Also, the jetifier alone was not enough to upgrade this library, so it may not be enough to downgrade it. I'm not sure.

#### Which issue(s) is it related to?

Fixes gh-280

#### How to test:

Clone and checkout the `fix` branch of [this example repo](https://github.com/timmywil/react-native-music-control-example/tree/fix).