### PR TITLE
fix(android): error can't find symbol Notification

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -170,7 +170,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
             createChannel(context);
         }
         nb = new NotificationCompat.Builder(context, CHANNEL_ID);
-        nb.setVisibility(Notification.VISIBILITY_PUBLIC);
+        nb.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
 
         updateNotificationMediaStyle();
 


### PR DESCRIPTION
#### What's this PR does?
Fix an android build error

#### Which issue(s) is it related to?
None because the last npm release failed and I found the issue when I tried to use master directly
