### PR TITLE
Move stopForegroundService() to onStop event

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
@@ -38,11 +38,11 @@ public class MusicControlEventEmitter {
     }
 
     public void onPause() {
-        stopForegroundService();
         sendEvent(context, "pause", null);
     }
 
     public void onStop() {
+        stopForegroundService();
         sendEvent(context, "stop", null);
     }
 


### PR DESCRIPTION
#### What's this PR does?
Move's the `stopForegroundService();` to the `onStop` event. 

#### Which issue(s) is it related to?
#286 

#### Screenshots (if appropriate)

#### How to test:
Once change is made perform the following:

1. Play audio from within App.
2. Go to either the lock screen or the notifications drawer.
3. Press the pause button on the music control notification.
4. Press the play button on the notification (notification should remain the same and continue to update instead of being destroyed).