### PR TITLE
Handle Audio onFocusChanged if paused

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlAudioFocusListener.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlAudioFocusListener.java
@@ -31,8 +31,10 @@ public class MusicControlAudioFocusListener implements AudioManager.OnAudioFocus
             mPlayOnAudioFocus = false;
             emitter.onStop();
         } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT) {
-            mPlayOnAudioFocus = true;
-            emitter.onPause();
+            if (MusicControlModule.INSTANCE.isPlaying()) {
+                mPlayOnAudioFocus = true;
+                emitter.onPause();
+            }
         } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
             volume.setCurrentVolume(40);
         } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlAudioFocusListener.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlAudioFocusListener.java
@@ -14,6 +14,8 @@ public class MusicControlAudioFocusListener implements AudioManager.OnAudioFocus
     private AudioManager mAudioManager;
     private AudioFocusRequest mFocusRequest;
 
+    private boolean mPlayOnAudioFocus = false;
+
     MusicControlAudioFocusListener(ReactApplicationContext context, MusicControlEventEmitter emitter,
                                    MusicControlVolumeListener volume) {
         this.emitter = emitter;
@@ -25,8 +27,11 @@ public class MusicControlAudioFocusListener implements AudioManager.OnAudioFocus
     @Override
     public void onAudioFocusChange(int focusChange) {
         if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
+            abandonAudioFocus();
+            mPlayOnAudioFocus = false;
             emitter.onStop();
         } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT) {
+            mPlayOnAudioFocus = true;
             emitter.onPause();
         } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
             volume.setCurrentVolume(40);
@@ -34,7 +39,10 @@ public class MusicControlAudioFocusListener implements AudioManager.OnAudioFocus
             if (volume.getCurrentVolume() != 100) {
                 volume.setCurrentVolume(100);
             }
-            emitter.onPlay();
+            if (mPlayOnAudioFocus) {
+                emitter.onPlay();
+            }
+            mPlayOnAudioFocus = false;
         }
     }
 

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -557,4 +557,8 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         PAUSED,
         NEVER
     }
+
+    public boolean isPlaying() {
+        return isPlaying;
+    }
 }

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -171,6 +171,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         }
         nb = new NotificationCompat.Builder(context, CHANNEL_ID);
         nb.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+         nb.setPriority(NotificationCompat.PRIORITY_HIGH);
 
         updateNotificationMediaStyle();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-music-control",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Add information on lockscreen and control playing music",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-music-control",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Add information on lockscreen and control playing music",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-music-control",
-  "version": "0.10.8",
+  "version": "0.10.6",
   "description": "Add information on lockscreen and control playing music",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
#### What's this PR does?
Fixes an issue on Android, related to starts playing an audio (which is paused) after another app finishes an audio
Implementation based on this [article](https://medium.com/androiddevelopers/audio-focus-3-cdc09da9c122)
#### Which issue(s) is it related to?
If another app starts and audio it calls `onAudioFocusChange` and returns `AUDIOFOCUS_LOSS_TRANSIENT`
After the app finished the audio, `onAudioFocusChange` is called again and returns `AUDIOFOCUS_GAIN` 
Which is great, that handles audio interruptions, and return to play the audio after another app finishes it

But, **if the audio is paused**, it's also calls `AUDIOFOCUS_GAIN` and also s**tart playing the audio** again

```
if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
            emitter.onStop();
        } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT) {
            emitter.onPause();
        } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
            volume.setCurrentVolume(40);
        } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
            if (volume.getCurrentVolume() != 100) {
                volume.setCurrentVolume(100);
            }
            emitter.onPlay();
        }
```

The fix checks if the audio is playing on `AUDIOFOCUS_LOSS_TRANSIENT`, and only enables to start again (`mPlayOnAudioFocus`) if it was playing

```
if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
            abandonAudioFocus();
            mPlayOnAudioFocus = false;
            emitter.onStop();
        } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT) {
            if (MusicControlModule.INSTANCE.isPlaying()) {
                mPlayOnAudioFocus = true;
                emitter.onPause();
            }
        } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
            volume.setCurrentVolume(40);
        } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
            if (volume.getCurrentVolume() != 100) {
                volume.setCurrentVolume(100);
            }
            if (mPlayOnAudioFocus) {
                emitter.onPlay();
            }
            mPlayOnAudioFocus = false;
        }
```
#### Screenshots (if appropriate)

#### How to test:
#### Test if is playing
1. Start playing an audio
2. Opens another app and start playing another audio
3. After the audio finishes playing, make sure that the audio of your app starts playing again
#### Test if is paused
1. Pause the audio on the NotificationBar
2. Opens another app and start playing another audio
3. After the audio finishes playing, make sure that the audio of your app **does not**  starts playing
