### PR TITLE
Fix the app crash when run on android api level <= 23

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -118,7 +118,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
     }
 
     private void updateNotificationMediaStyle() {
-        if (!(Build.MANUFACTURER.toLowerCase(Locale.getDefault()).contains("huawei") && Build.VERSION.SDK_INT < Build.VERSION_CODES.M)) {
+        if (!Build.MANUFACTURER.toLowerCase(Locale.getDefault()).contains("huawei") && Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
             MediaStyle style = new MediaStyle();
             style.setMediaSession(session.getSessionToken());
             int controlCount = 0;


### PR DESCRIPTION
Adapt run all android api level

#### What's this PR does?
Fix the app crash when run on android api level <= 23
Adapt run all android api level.

#### Which issue(s) is it related to?
related in function
```
private void updateNotificationMediaStyle()
```
The current code:
```
 if (!(Build.MANUFACTURER.toLowerCase(Locale.getDefault()).contains("huawei") && Build.VERSION.SDK_INT < Build.VERSION_CODES.M)) {
```
We should compare android device have no `huawei` and `Build.VERSION.SDK_INT > Build.VERSION_CODES.M`
```
 if (!Build.MANUFACTURER.toLowerCase(Locale.getDefault()).contains("huawei") && Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
```
#### Screenshots (if appropriate)
Because i test on emulator and the app crash so i cant take a screenshots.
#### How to test:
We could run on emluator with android api level > 23 and <= 23.