### PR TITLE
Stop Foreground Service directly instead of starting and then stoping in onStartCommand.

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
@@ -2,12 +2,15 @@ package com.tanguyantoine.react;
 
 import android.content.Intent;
 import android.os.Build;
-import androidx.core.content.ContextCompat;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import androidx.core.app.NotificationManagerCompat;
+
+import static com.tanguyantoine.react.MusicControlModule.NOTIFICATION_ID;
 
 public class MusicControlEventEmitter {
     private static void sendEvent(ReactApplicationContext context, String type, Object value) {
@@ -79,10 +82,11 @@ public class MusicControlEventEmitter {
     }
 
     private void stopForegroundService() {
+        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            Intent intent = new Intent(context, MusicControlNotification.NotificationService.class);
-            intent.setAction("StopService");
-            ContextCompat.startForegroundService(context, intent);
+            Intent myIntent =
+                    new Intent(context, MusicControlNotification.NotificationService.class);
+            context.stopService(myIntent);
         }
     }
 }

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -1,26 +1,22 @@
 package com.tanguyantoine.react;
 
 import android.app.Notification;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.IBinder;
-import androidx.core.app.NotificationCompat;
-import androidx.core.app.NotificationManagerCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
 import android.view.KeyEvent;
+
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReadableMap;
 
 import java.util.Map;
 
-import static androidx.core.app.NotificationCompat.PRIORITY_MIN;
-import static com.tanguyantoine.react.MusicControlModule.CHANNEL_ID;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
 import static com.tanguyantoine.react.MusicControlModule.NOTIFICATION_ID;
 
 public class MusicControlNotification {
@@ -82,7 +78,7 @@ public class MusicControlNotification {
 
     /**
      * NOTE: Synchronized since the NotificationService called prepare without a re-entrant lock.
-     *       Other call sites (e.g. show/hide in module) are already synchronized.
+     * Other call sites (e.g. show/hide in module) are already synchronized.
      */
     public synchronized Notification prepareNotification(NotificationCompat.Builder builder, boolean isPlaying) {
         // Add the buttons
@@ -187,35 +183,22 @@ public class MusicControlNotification {
             return null;
         }
 
-        private boolean isRunning;
-        private Notification notification;
-
         @Override
         public void onCreate() {
             super.onCreate();
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                notification = MusicControlModule.INSTANCE.notification.prepareNotification(MusicControlModule.INSTANCE.nb, false);
-                startForeground(NOTIFICATION_ID, notification);
-                isRunning = true;
-            }
         }
 
         @Override
         public int onStartCommand(Intent intent, int flags, int startId) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                if (intent.getAction() != null && intent.getAction().equals("StopService") && notification != null && isRunning) {
-                    stopForeground(true);
-                    isRunning = false;
-                    stopSelf();
-                }
+                Notification notification = MusicControlModule.INSTANCE.notification.prepareNotification(MusicControlModule.INSTANCE.nb, false);
+                startForeground(NOTIFICATION_ID, notification);
             }
             return START_NOT_STICKY;
         }
 
         @Override
         public void onTaskRemoved(Intent rootIntent) {
-            isRunning = false;
             // Destroy the notification and sessions when the task is removed (closed, killed, etc)
             if (MusicControlModule.INSTANCE != null) {
                 MusicControlModule.INSTANCE.destroy();
@@ -228,7 +211,6 @@ public class MusicControlNotification {
 
         @Override
         public void onDestroy() {
-            isRunning = false;
 
             if (MusicControlModule.INSTANCE != null) {
                 MusicControlModule.INSTANCE.destroy();


### PR DESCRIPTION
Stop Foreground Service directly instead of starting the service and then stopping in onStartCommand.

#### What's this PR does?
Tries to fix part of crash mentioned in #244 

#### Which issue(s) is it related to?
As per crash log App crashes in `onCreate` method of `NotificationService`.

And as per logs from our App, Service was started right after callback on `onAudioFocusChange` with `AudioManager.AUDIOFOCUS_LOSS`.

This means that, App is crashing only when we try to stop foreground service.

So, instead of starting service and then stopping in onStartCommand. We can stop service by directly calling stop service. Same as how we stop service in `MusicControlNotification::hide` method.

#### Screenshots (if appropriate)
NA
#### How to test:
Unfortunately I do not reproduction steps.