### PR TITLE
[Android] - Notification Id & Channel Name support

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControl.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControl.java
@@ -18,7 +18,7 @@ public class MusicControl implements ReactPackage {
         modules.add(new MusicControlModule(context));
         return modules;
     }
- 
+
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext context) {
         return Collections.emptyList();

--- a/android/src/main/java/com/tanguyantoine/react/MusicControl.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControl.java
@@ -18,7 +18,7 @@ public class MusicControl implements ReactPackage {
         modules.add(new MusicControlModule(context));
         return modules;
     }
-
+ 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext context) {
         return Collections.emptyList();

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
@@ -10,8 +10,6 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import androidx.core.app.NotificationManagerCompat;
 
-import static com.tanguyantoine.react.MusicControlModule.NOTIFICATION_ID;
-
 public class MusicControlEventEmitter {
     private static void sendEvent(ReactApplicationContext context, String type, Object value) {
         WritableMap data = Arguments.createMap();
@@ -35,6 +33,7 @@ public class MusicControlEventEmitter {
 
     MusicControlEventEmitter(ReactApplicationContext context, int notificationId) {
         this.context = context;
+        this.notificationId = notificationId;
     }
 
     public void setNotificationId(int notificationId) {

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
@@ -31,9 +31,14 @@ public class MusicControlEventEmitter {
     }
 
     private final ReactApplicationContext context;
+    private int notificationId;
 
-    MusicControlEventEmitter(ReactApplicationContext context) {
+    MusicControlEventEmitter(ReactApplicationContext context, int notificationId) {
         this.context = context;
+    }
+
+    public void setNotificationId(int notificationId) {
+        this.notificationId = notificationId;
     }
 
     public void onPlay() {

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
@@ -87,7 +87,7 @@ public class MusicControlEventEmitter {
     }
 
     private void stopForegroundService() {
-        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID);
+        NotificationManagerCompat.from(context).cancel(notificationId);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Intent myIntent =
                     new Intent(context, MusicControlNotification.NotificationService.class);

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -117,10 +117,8 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         mChannel.setLockscreenVisibility(NotificationCompat.VISIBILITY_PUBLIC);
         mNotificationManager.createNotificationChannel(mChannel);
         this.notificationChannel = mChannel;
-    }
 
-    private void createNotificationBuilder() {
-        nb = new NotificationCompat.Builder(context, notificationChannel);
+        nb = new NotificationCompat.Builder(context, notificationChannel.getId());
         nb.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
         nb.setPriority(NotificationCompat.PRIORITY_HIGH);
     }
@@ -186,7 +184,9 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         md = new MediaMetadataCompat.Builder();
         pb = new PlaybackStateCompat.Builder();
         pb.setActions(controls);
-        createNotificationBuilder();
+        nb = new NotificationCompat.Builder(context, DEFAULT_CHANNEL_ID);
+        nb.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+        nb.setPriority(NotificationCompat.PRIORITY_HIGH);
 
         updateNotificationMediaStyle();
 
@@ -274,7 +274,6 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             String channelId = metadata.hasKey("channelId") ? metadata.getString("channelId") : DEFAULT_CHANNEL_ID;
             createChannel(context, channelId);
-            createNotificationBuilder();
         }
 
         String title = metadata.hasKey("title") ? metadata.getString("title") : null;

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -119,6 +119,12 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         this.notificationChannel = mChannel;
     }
 
+    private void createNotificationBuilder() {
+        nb = new NotificationCompat.Builder(context, notificationChannel);
+        nb.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+        nb.setPriority(NotificationCompat.PRIORITY_HIGH);
+    }
+
     private boolean hasControl(long control) {
         if((controls & control) == control) {
             return true;
@@ -162,7 +168,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
         context = getReactApplicationContext();
 
-        emitter = new MusicControlEventEmitter(context);
+        emitter = new MusicControlEventEmitter(context, DEFAULT_NOTIFICATION_ID);
 
         session = new MediaSessionCompat(context, "MusicControl");
         session.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS |
@@ -180,10 +186,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         md = new MediaMetadataCompat.Builder();
         pb = new PlaybackStateCompat.Builder();
         pb.setActions(controls);
-
-        nb = new NotificationCompat.Builder(context, CHANNEL_ID);
-        nb.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
-         nb.setPriority(NotificationCompat.PRIORITY_HIGH);
+        createNotificationBuilder();
 
         updateNotificationMediaStyle();
 
@@ -271,6 +274,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             String channelId = metadata.hasKey("channelId") ? metadata.getString("channelId") : DEFAULT_CHANNEL_ID;
             createChannel(context, channelId);
+            createNotificationBuilder();
         }
 
         String title = metadata.hasKey("title") ? metadata.getString("title") : null;

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -266,6 +266,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
         final int notificationId = metadata.hasKey("notificationId") ? metadata.getInt("notificationId") : DEFAULT_NOTIFICATION_ID;
         emitter.setNotificationId(notificationId);
+        notification.setNotificationId(notificationId);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             String channelId = metadata.hasKey("channelId") ? metadata.getString("channelId") : DEFAULT_CHANNEL_ID;
@@ -347,7 +348,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
                     }
                     if(nb != null) {
                         nb.setLargeIcon(bitmap);
-                        notification.show(nb, isPlaying, notificationId);
+                        notification.show(nb, isPlaying);
                     }
 
                     artworkThread = null;
@@ -361,7 +362,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
         session.setMetadata(md.build());
         session.setActive(true);
-        notification.show(nb, isPlaying, notificationId);
+        notification.show(nb, isPlaying);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -264,7 +264,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         init();
         if(artworkThread != null && artworkThread.isAlive()) artworkThread.interrupt();
 
-        int notificationId = metadata.hasKey("notificationId") ? metadata.getInt("notificationId") : DEFAULT_NOTIFICATION_ID;
+        final int notificationId = metadata.hasKey("notificationId") ? metadata.getInt("notificationId") : DEFAULT_NOTIFICATION_ID;
         emitter.setNotificationId(notificationId);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -347,7 +347,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
                     }
                     if(nb != null) {
                         nb.setLargeIcon(bitmap);
-                        notification.show(nb, isPlaying);
+                        notification.show(nb, isPlaying, notificationId);
                     }
 
                     artworkThread = null;
@@ -361,7 +361,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
         session.setMetadata(md.build());
         session.setActive(true);
-        notification.show(nb, isPlaying);
+        notification.show(nb, isPlaying, notificationId);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -116,8 +116,8 @@ public class MusicControlNotification {
         return builder.build();
     }
 
-    public synchronized void show(NotificationCompat.Builder builder, boolean isPlaying) {
-        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, prepareNotification(builder, isPlaying));
+    public synchronized void show(NotificationCompat.Builder builder, boolean isPlaying, int notificationId) {
+        NotificationManagerCompat.from(context).notify(notificationId, prepareNotification(builder, isPlaying));
     }
 
     public void hide() {


### PR DESCRIPTION
#### What's this PR does?
Can now set notification id and channel id from React (before these were statically assigned). 

#### How to test:
When calling setNowPlaying can now add the following on Android:
```
setNowPlaying({
   "notificationId": 10,
   "channelId": "some-channel-name"
   "artist": ...,
   ...
})
```