### PR TITLE
Android Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ MusicControl.setNowPlaying({
   genre: 'Post-disco, Rhythm and Blues, Funk, Dance-pop',
   duration: 294, // (Seconds)
   description: '', // Android Only
-  color: 0xFFFFFF, // Notification Color - Android Only
+  color: 0xFFFFFF, // Android Only - Notification Color
+  colorized: true, // Android 8+ Only - Notification Color extracted from the artwork. Set to false to use the color property instead
   date: '1983-01-02T00:00:00Z', // Release Date (RFC 3339) - Android Only
   rating: 84, // Android Only (Boolean or Number depending on the type)
   notificationIcon: 'my_custom_icon' // Android Only (String), Android Drawable resource name for a custom notification icon
@@ -241,6 +242,7 @@ componentDidMount() {
 
 * Android only supports the intervals 5, 10, & 30, while iOS supports any number
 * The interval value only changes what number displays in the UI, the actual logic to skip forward or backward by a given amount must be implemented in the appropriate callbacks
+* Android 10+ does support the seek bar in the notification, but only when meeting specific requirements: setNowPlaying() must be called with a duration value before enabling any controls
 * When using [react-native-sound](https://github.com/zmxv/react-native-sound) for audio playback, make sure that on iOS `mixWithOthers` is set to `false` in [`Sound.setCategory(value, mixWithOthers)`](https://github.com/zmxv/react-native-sound#soundsetcategoryvalue-mixwithothers-ios-only). MusicControl will not work on a real device when this is set to `true`.
 * For lockscreen controls to appear enabled instead of greyed out, the accompanying listener for each control that you want to display on the lock screen must contain a valid function:
 

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -362,11 +362,13 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         int maxVol = info.hasKey("maxVolume") ? info.getInt("maxVolume") : volume.getMaxVolume();
         int vol = info.hasKey("volume") ? info.getInt("volume") : volume.getCurrentVolume();
         ratingType = info.hasKey("rating") ? info.getInt("rating") : ratingType;
-
-		// The default speed is 0 if it was never supplied. Adjust this to 1 to ensure that the seek bar progresses properly
-		if (speed == 0) {
-			speed = 1;
-		}
+        
+        isPlaying = pbState == PlaybackStateCompat.STATE_PLAYING || pbState == PlaybackStateCompat.STATE_BUFFERING;
+                
+        // The default speed is 0 if it was never supplied. Adjust this to 1 if player is playing to ensure that the seek bar progresses properly
+        if (isPlaying && speed == 0) {
+            speed = 1;
+        }
 
         if(info.hasKey("elapsedTime")) {
             elapsedTime = (long)(info.getDouble("elapsedTime") * 1000);
@@ -380,7 +382,6 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         pb.setBufferedPosition(bufferedTime);
         pb.setActions(controls);
 
-        isPlaying = pbState == PlaybackStateCompat.STATE_PLAYING || pbState == PlaybackStateCompat.STATE_BUFFERING;
         if(session.isActive()) notification.show(nb, isPlaying);
 
         state = pb.build();


### PR DESCRIPTION
This PR fixes 3 Android issues I came across.

1. The skipBackward and skipForward intervals only worked the first time a notification was created. If controls were stopped with stopControl() and then re-created, the intervals didn't take effect and would only show the 10 second icon. They have to be re-applied during the init method

2. If a color value was supplied, then there was a "removeFade" logic that reset the media style. Unfortunately, this prevented actions from appearing in compact view and also prevented the seek bar from appearing (Android 10+ only). A better workaround seems to be to instead use NotificationCompat.Builder's setColorized method to prevent Android from using colors it extracts from the artwork. For optimal flexibility, I added a "colorized" property which allows a few different scenarios:
  - Setting a color value, but not isColorized will result in the color showing for all versions of Android
  - Setting a color value and isColorized=false will also result in the color showing for all versions
  - Setting a color value and isColorized=true will result in the color showing on Android < 8.0, while still allowing Android 8.0+ to extract the color from the artwork
  - If neither the color nor isColorized values are provided, then Android < 8.0 will default to the grey color, while Android 8.0+ will extract the color from the artwork

3. The seek bar is supported in Android 10+, but didn't auto-increment during playback if a speed value wasn't explicitly supplied. In that case the speed would default to 0, which is invalid. The default speed should instead be 1, indicating normal playback
