### PR TITLE
[Android] Add setNotificationIds function to MusicControl

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Resets, hides the music controls and disables everything.
 MusicControl.stopControl()
 ```
 
+### Set notification id and channel id (Android Only). 
+```javascript
+MusicControl.setNotificationId(10, "channel")
+```
+If you want to change the default notification id and channel name, call this once before displaying any notifications. 
+
 ---
 
 There is also a `closeNotification` control on Android controls the swipe behavior of the audio playing notification, and accepts additional configuration options with the `when` key:

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlEventEmitter.java
@@ -10,8 +10,6 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import androidx.core.app.NotificationManagerCompat;
 
-import static com.tanguyantoine.react.MusicControlModule.NOTIFICATION_ID;
-
 public class MusicControlEventEmitter {
     private static void sendEvent(ReactApplicationContext context, String type, Object value) {
         WritableMap data = Arguments.createMap();
@@ -31,9 +29,11 @@ public class MusicControlEventEmitter {
     }
 
     private final ReactApplicationContext context;
+    private int notificationId;
 
-    MusicControlEventEmitter(ReactApplicationContext context) {
+    MusicControlEventEmitter(ReactApplicationContext context, int notificationId) {
         this.context = context;
+        this.notificationId = notificationId;
     }
 
     public void onPlay() {
@@ -82,7 +82,7 @@ public class MusicControlEventEmitter {
     }
 
     private void stopForegroundService() {
-        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID);
+        NotificationManagerCompat.from(context).cancel(notificationId);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Intent myIntent =
                     new Intent(context, MusicControlNotification.NotificationService.class);

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -69,9 +69,8 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
     public NotificationClose notificationClose = NotificationClose.PAUSED;
 
-    public static final String CHANNEL_ID = "react-native-music-control";
-
-    public static final int NOTIFICATION_ID = 100;
+    private String channelId = "react-native-music-control";
+    private int notificationId = 100;
 
     public MusicControlModule(ReactApplicationContext context) {
         super(context);
@@ -104,7 +103,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
     private void createChannel(ReactApplicationContext context) {
         NotificationManager mNotificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
-        NotificationChannel mChannel = new NotificationChannel(CHANNEL_ID, "Media playback", NotificationManager.IMPORTANCE_LOW);
+        NotificationChannel mChannel = new NotificationChannel(channelId, "Media playback", NotificationManager.IMPORTANCE_LOW);
         mChannel.setDescription("Media playback controls");
         mChannel.setShowBadge(false);
         mChannel.setLockscreenVisibility(NotificationCompat.VISIBILITY_PUBLIC);
@@ -147,6 +146,10 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         }
     }
 
+    public int getNotificationId() {
+        return notificationId;
+    }
+
     public void init() {
         if (init) return;
 
@@ -154,7 +157,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
         context = getReactApplicationContext();
 
-        emitter = new MusicControlEventEmitter(context);
+        emitter = new MusicControlEventEmitter(context, notificationId);
 
         session = new MediaSessionCompat(context, "MusicControl");
         session.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS |
@@ -176,7 +179,7 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             createChannel(context);
         }
-        nb = new NotificationCompat.Builder(context, CHANNEL_ID);
+        nb = new NotificationCompat.Builder(context, channelId);
         nb.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
          nb.setPriority(NotificationCompat.PRIORITY_HIGH);
 
@@ -204,6 +207,12 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
         isPlaying = false;
         init = true;
+    }
+
+    @ReactMethod
+    public synchronized  void setNotificationIds(int notificationId, String channelId) {
+        this.notificationId = notificationId;
+        this.channelId = channelId;
     }
 
     @ReactMethod

--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -17,8 +17,6 @@ import java.util.Map;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
-import static com.tanguyantoine.react.MusicControlModule.NOTIFICATION_ID;
-
 public class MusicControlNotification {
 
     protected static final String REMOVE_NOTIFICATION = "music_control_remove_notification";
@@ -117,11 +115,11 @@ public class MusicControlNotification {
     }
 
     public synchronized void show(NotificationCompat.Builder builder, boolean isPlaying) {
-        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, prepareNotification(builder, isPlaying));
+        NotificationManagerCompat.from(context).notify(MusicControlModule.INSTANCE.getNotificationId(), prepareNotification(builder, isPlaying));
     }
 
     public void hide() {
-        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID);
+        NotificationManagerCompat.from(context).cancel(MusicControlModule.INSTANCE.getNotificationId());
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 
@@ -189,14 +187,14 @@ public class MusicControlNotification {
         public void onCreate() {
             super.onCreate();
             notification = MusicControlModule.INSTANCE.notification.prepareNotification(MusicControlModule.INSTANCE.nb, false);
-            startForeground(NOTIFICATION_ID, notification);
+            startForeground(MusicControlModule.INSTANCE.getNotificationId(), notification);
         }
 
         @Override
         public int onStartCommand(Intent intent, int flags, int startId) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 notification = MusicControlModule.INSTANCE.notification.prepareNotification(MusicControlModule.INSTANCE.nb, false);
-                startForeground(NOTIFICATION_ID, notification);
+                startForeground(MusicControlModule.INSTANCE.getNotificationId(), notification);
             }
             return START_NOT_STICKY;
         }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -12,6 +12,7 @@ declare const MusicControl: {
     RATING_4_STARS: any;
     RATING_5_STARS: any;
     RATING_PERCENTAGE: any;
+    setNotificationIds: (notificationId: number, channelId: String) => void;
     enableBackgroundMode: (enable: boolean) => void;
     setNowPlaying: (info: TPlayingInfo) => void;
     setPlayback: (info: TPlayingInfo) => void;

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,11 @@ var MusicControl = {
     enableBackgroundMode: function (enable) {
         NativeMusicControl.enableBackgroundMode(enable);
     },
+    setNotificationIds: function (notificationId, channelId) {
+        if (IS_ANDROID) {
+            NativeMusicControl.setNotificationIds(notificationId, channelId)
+        }
+    },
     setNowPlaying: function (info) {
         // Check if we have an android asset from react style image require
         if (info.artwork) {


### PR DESCRIPTION
#### What's this PR does?
Add a new Android-only function to MusicControl: `setNotificationIds(notificationId: number, channelName: String)`. Before these were statically set in the source-code, however it would be useful to set these from within the js. 