### PR TITLE
Fixing null object reference

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -107,7 +107,11 @@ public class MusicControlNotification {
         // Open the app when the notification is clicked
         String packageName = context.getPackageName();
         Intent openApp = context.getPackageManager().getLaunchIntentForPackage(packageName);
-        builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, 0));
+        try {
+            builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, 0));
+        }catch(Exception e){
+            System.out.println(e.getMessage());
+        }
 
         // Remove notification
         Intent remove = new Intent(REMOVE_NOTIFICATION);


### PR DESCRIPTION
#### What's this PR does?
This fix a problem occurring in Android 10+ (running emulators) throwing null object reference because the intent is not ready.

#### Which issue(s) is it related to?
https://github.com/tanguyantoine/react-native-music-control/issues/348

#### How to test:
Execute the base code provided in the examples in a simulator using Android 10+ (API 30)