### PR TITLE
iOS Live Stream Indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ MusicControl.setNowPlaying({
   colorized: true, // Android 8+ Only - Notification Color extracted from the artwork. Set to false to use the color property instead
   date: '1983-01-02T00:00:00Z', // Release Date (RFC 3339) - Android Only
   rating: 84, // Android Only (Boolean or Number depending on the type)
-  notificationIcon: 'my_custom_icon' // Android Only (String), Android Drawable resource name for a custom notification icon
+  notificationIcon: 'my_custom_icon', // Android Only (String), Android Drawable resource name for a custom notification icon
+  isLiveStream: true // iOS Only (Boolean), Show or hide Live Indicator instead of seekbar on lock screen for live streams. Default value is false.
 })
 ```
 

--- a/ios/MusicControlManager.m
+++ b/ios/MusicControlManager.m
@@ -37,7 +37,8 @@
     @"playbackQueueIndex": MPNowPlayingInfoPropertyPlaybackQueueIndex, \
     @"playbackQueueCount": MPNowPlayingInfoPropertyPlaybackQueueCount, \
     @"chapterNumber": MPNowPlayingInfoPropertyChapterNumber, \
-    @"chapterCount": MPNowPlayingInfoPropertyChapterCount \
+    @"chapterCount": MPNowPlayingInfoPropertyChapterCount, \
+    @"isLiveStream": MPNowPlayingInfoPropertyIsLiveStream \
 }
 
 @implementation MusicControlManager


### PR DESCRIPTION
#### What's this PR does?
This PR includes changes to add live stream indicator for live stream (iOS).

#### Which issue(s) is it related to?
Possible to show live indicator instead of progress scrubber? #190 

#### Screenshots (if appropriate)
![47857284-9dc18e80-ddbf-11e8-98b0-43f2bdc60382](https://user-images.githubusercontent.com/31098907/95961531-d7a1c900-0e0d-11eb-9757-b4ec1c4aec51.png)

#### How to test:
Pass isLiveStream prop true to MusicControl.setNowPlaying method. 
Default value is false.