### PR TITLE
fixed hide method to work with older SDKs (Android)

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -128,11 +128,11 @@ public class MusicControlNotification {
     public void hide() {
         NotificationManagerCompat.from(context).cancel(MusicControlModule.INSTANCE.getNotificationId());
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-
+        try {
             Intent myIntent = new Intent(context, MusicControlNotification.NotificationService.class);
             context.stopService(myIntent);
-
+        }catch(Exception e){
+            System.out.println(e.getMessage());
         }
     }
 


### PR DESCRIPTION
#### What's this PR does?
It fixes the problem that the 'hide' method doesn't work with SDKs older than 26 (Android).

#### Which issue(s) is it related to?
It is not related to any issues.

#### How to test:
With an Android SDK older than 26, try to enable the music controller then stop it. You'll see that controls didn't hide.
