### PR TITLE
Makes Command ENUM Optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ const MusicControl = {
   enableControl: function(controlName: string, enable: boolean, options = {}) {
     NativeMusicControl.enableControl(controlName, enable, options || {})
   },
-  handleCommand: function(commandName: Command, value: any) {
+  handleCommand: function(commandName: Command | string, value: any) {
     if (handlers[commandName]) {
       //@ts-ignore
       handlers[commandName](value)


### PR DESCRIPTION
This will allow strings to still work on the `MusicControl.on` function.

#### What's this PR does?

#### Which issue(s) is it related to?

#358 

#### Screenshots (if appropriate)

<img width="1522" alt="Screen Shot 2020-11-17 at 9 47 38 AM" src="https://user-images.githubusercontent.com/2659478/99406585-0ce18100-28bc-11eb-845e-721b71397638.png">


#### How to test:

Pass a string and watch the ts error go away
