### PR TITLE
Fix Xcode 12 build errors

### DIFF
--- a/react-native-music-control.podspec
+++ b/react-native-music-control.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
This affects projects that make use of use_frameworks! in their podspec.
It seems that many projects we're using the wrong dependency.
