### PR TITLE
Adding mavenCentral() as jcenter() is shutting

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ def safeExtGet(prop, fallback) {
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 


### PR DESCRIPTION
Adding mavenCentral() as jcenter() is shutting down

#### What's this PR does?

Adding mavenCentral() and removing jcenter() from build.gradle