### PR TITLE
Foreground crash fix in android

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -212,7 +212,11 @@ public class MusicControlNotification {
                 Intent intent = new Intent(MusicControlNotification.NotificationService.this, MusicControlNotification.NotificationService.class);
                 // service has already been initialized.
                 // startForeground method should be called within 5 seconds.
-                ContextCompat.startForegroundService(MusicControlNotification.NotificationService.this, intent);
+                try {
+                    ContextCompat.startForegroundService(MusicControlNotification.NotificationService.this, intent);
+                }catch (Exception ex){
+                    ex.printStackTrace();
+                } 
 
                 if(MusicControlModule.INSTANCE == null){
                     try {


### PR DESCRIPTION
```
Context.startForegroundService() did not then call Service.startForeground(): 
ServiceRecord{360f674 u0 com.project.bundleid/com.tanguyantoine.react.MusicControlNotification$NotificationService}
```

@bradleyflood Please review this in your availability and if it is proper then merge otherwise close it...I am not sure if this might fix the crash...It will still take a couple of days for me to test it thoroughly

