### PR TITLE
Fix Android Apps crashing when targeting v12 / SDK31

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -108,7 +108,7 @@ public class MusicControlNotification {
         String packageName = context.getPackageName();
         Intent openApp = context.getPackageManager().getLaunchIntentForPackage(packageName);
         try {
-            builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, 0));
+            builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, PendingIntent.FLAG_IMMUTABLE));
         }catch(Exception e){
             System.out.println(e.getMessage());
         }
@@ -116,7 +116,7 @@ public class MusicControlNotification {
         // Remove notification
         Intent remove = new Intent(REMOVE_NOTIFICATION);
         remove.putExtra(PACKAGE_NAME, context.getApplicationInfo().packageName);
-        builder.setDeleteIntent(PendingIntent.getBroadcast(context, 0, remove, PendingIntent.FLAG_UPDATE_CURRENT));
+        builder.setDeleteIntent(PendingIntent.getBroadcast(context, 0, remove, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT));
 
         return builder.build();
     }
@@ -176,7 +176,7 @@ public class MusicControlNotification {
         Intent intent = new Intent(MEDIA_BUTTON);
         intent.putExtra(Intent.EXTRA_KEY_EVENT, new KeyEvent(KeyEvent.ACTION_DOWN, keyCode));
         intent.putExtra(PACKAGE_NAME, packageName);
-        PendingIntent i = PendingIntent.getBroadcast(context, keyCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent i = PendingIntent.getBroadcast(context, keyCode, intent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
 
         return new NotificationCompat.Action(icon, title, i);
     }


### PR DESCRIPTION
#### What's this PR does?
Conforming lib to [Behavior changes: Apps targeting Android 12 - Pending intents mutability](https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability).
Fixes Android Apps crashing when `compileSdkVersion` and/or `targetSdkVersion` is set to 31.

#### Which issue(s) is it related to?
/

#### Screenshots (if appropriate)
/

#### How to test:
1. Setup Example Project without this PR
2. Call one of following methods and the App will crash
  - `MusicControl.on(Command.play, ()=> {})`
  - `MusicControl.on(Command.pause, ()=> {})`

```err
E/unknown:ReactNative: Exception in native call
    java.lang.IllegalArgumentException: com.app.name: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:375)
        at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:645)
        at android.app.PendingIntent.getBroadcast(PendingIntent.java:632)
        at com.tanguyantoine.react.MusicControlNotification.createAction(MusicControlNotification.java:179)
        at com.tanguyantoine.react.MusicControlNotification.updateActions(MusicControlNotification.java:61)
        at com.tanguyantoine.react.MusicControlModule.enableControl(MusicControlModule.java:565)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
        at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:188)
        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
        at java.lang.Thread.run(Thread.java:920)
```

3. Setup Example Project with this PR
4. Call one of following methods
  - `MusicControl.on(Command.play, ()=> {})`
  - `MusicControl.on(Command.pause, ()=> {})`
5.  The App won't crash nor show an error message