### PR TITLE
Add foregroundServiceType to Android Manifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
           package="com.tanguyantoine.react">
 
     <application>
-        <service android:stopWithTask="true" android:name=".MusicControlNotification$NotificationService" />
+        <service android:stopWithTask="true" android:name=".MusicControlNotification$NotificationService" android:foregroundServiceType="mediaPlayback" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Fixes https://github.com/tanguyantoine/react-native-music-control/issues/400